### PR TITLE
fix: resolve 1.2GB memory leak in WeChat process detection

### DIFF
--- a/internal/wechat/process/windows/detector.go
+++ b/internal/wechat/process/windows/detector.go
@@ -2,6 +2,8 @@ package windows
 
 import (
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/process"
@@ -13,14 +15,30 @@ import (
 const (
 	V4ProcessName = "Weixin"
 	V4DBFile      = `db_storage\session\session.db`
+
+	// noDataDirRecheckInterval 无 DataDir 的主进程缓存过期时间。
+	// 覆盖场景：微信已启动但用户尚未登录 → 登录后 DataDir 出现。
+	noDataDirRecheckInterval = 30 * time.Second
 )
 
+// procCacheEntry 缓存单个主进程的检测结果
+type procCacheEntry struct {
+	info      *model.Process
+	hasData   bool      // DataDir 非空
+	checkedAt time.Time // 上次调用 getProcessInfo 的时间
+}
+
 // Detector 实现 Windows 平台的进程检测器
-type Detector struct{}
+type Detector struct {
+	mu    sync.Mutex
+	cache map[uint32]*procCacheEntry // PID → 缓存（仅主进程）
+}
 
 // NewDetector 创建一个新的 Windows 检测器
 func NewDetector() *Detector {
-	return &Detector{}
+	return &Detector{
+		cache: make(map[uint32]*procCacheEntry),
+	}
 }
 
 // FindProcesses 查找所有微信进程并返回它们的信息
@@ -31,7 +49,13 @@ func (d *Detector) FindProcesses() ([]*model.Process, error) {
 		return nil, err
 	}
 
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	alivePIDs := make(map[uint32]bool)
 	var result []*model.Process
+	now := time.Now()
+
 	for _, p := range processes {
 		name, err := p.Name()
 		name = strings.TrimSuffix(name, ".exe")
@@ -39,20 +63,54 @@ func (d *Detector) FindProcesses() ([]*model.Process, error) {
 			continue
 		}
 
-		cmdline, cmdlineErr := p.Cmdline()
+		pid := uint32(p.Pid)
+		alivePIDs[pid] = true
 
-		// 获取进程信息
+		// ── 子进程过滤 ──
+		// 微信 V4 的 Chromium 子进程 cmdline 含 --type=（wxocr/wxplayer/wxutility 等）。
+		// 主进程可能带 --scene= 等参数，但不会有 --type=。
+		// 子进程持有大量文件句柄，对其调 p.OpenFiles() 是内存暴涨的根因，必须在此拦截。
+		cmdline, err := p.Cmdline()
+		if err != nil {
+			log.Debug().Err(err).Msgf("获取进程 %d 命令行失败，跳过", p.Pid)
+			continue
+		}
+		if strings.Contains(cmdline, "--type=") {
+			continue
+		}
+
+		// ── 主进程 PID 缓存 ──
+		// 主进程只有1个，getProcessInfo(含 p.OpenFiles)开销可接受，
+		// 但仍做缓存以避免每 3 秒重复扫描。
+		if entry, ok := d.cache[pid]; ok {
+			if entry.hasData || now.Sub(entry.checkedAt) < noDataDirRecheckInterval {
+				result = append(result, entry.info)
+				continue
+			}
+			// 无 DataDir 且已超时 → 重新检测（覆盖用户登录场景）
+			delete(d.cache, pid)
+		}
+
+		// ── 实际检测 ──
 		procInfo, err := d.getProcessInfo(p)
 		if err != nil {
 			log.Err(err).Msgf("获取进程 %d 的信息失败", p.Pid)
 			continue
 		}
 
-		if cmdlineErr == nil && strings.Contains(cmdline, "--") && procInfo.DataDir == "" {
-			continue
+		d.cache[pid] = &procCacheEntry{
+			info:      procInfo,
+			hasData:   procInfo.DataDir != "",
+			checkedAt: now,
 		}
-
 		result = append(result, procInfo)
+	}
+
+	// 清理已退出进程的缓存
+	for pid := range d.cache {
+		if !alivePIDs[pid] {
+			delete(d.cache, pid)
+		}
 	}
 
 	return result, nil
@@ -66,7 +124,6 @@ func (d *Detector) getProcessInfo(p *process.Process) (*model.Process, error) {
 		Platform: model.PlatformWindows,
 	}
 
-	// 获取可执行文件路径
 	exePath, err := p.Exe()
 	if err != nil {
 		log.Err(err).Msg("获取可执行文件路径失败")
@@ -74,7 +131,6 @@ func (d *Detector) getProcessInfo(p *process.Process) (*model.Process, error) {
 	}
 	procInfo.ExePath = exePath
 
-	// 获取版本信息
 	versionInfo, err := appver.New(exePath)
 	if err != nil {
 		log.Err(err).Msg("获取版本信息失败")
@@ -83,10 +139,8 @@ func (d *Detector) getProcessInfo(p *process.Process) (*model.Process, error) {
 	procInfo.Version = versionInfo.Version
 	procInfo.FullVersion = versionInfo.FullVersion
 
-	// 初始化附加信息（数据目录、账户名）
 	if err := initializeProcessInfo(p, procInfo); err != nil {
 		log.Err(err).Msg("初始化进程信息失败")
-		// 即使初始化失败也返回部分信息
 	}
 
 	return procInfo, nil


### PR DESCRIPTION
## 问题

chatlog 运行时内存从正常的 40-60MB 飙升至 **1.2GB**，CPU 也明显偏高。

## 根因

`FindProcesses()` 每 3 秒被 TUI 刷新循环调用。微信 V4 基于 Chromium，会派生多个子进程（`--type=wxocr`、`--type=wxplayer`、`--type=wxutility` 等），每个持有大量文件句柄。

`8fe3d59` 将 `getProcessInfo()`（内含 `p.OpenFiles()` 枚举所有句柄）移到了 cmdline 过滤之前，导致每 3 秒对**所有子进程**执行昂贵的句柄枚举。

## 修复

1. **`--type=` 精确过滤**：Chromium 子进程的 cmdline 均含 `--type=`，主进程可能带 `--scene=` 但不会有 `--type=`。在调用 `getProcessInfo` 之前拦截子进程。
2. **PID 缓存**：对主进程检测结果按 PID 缓存，避免重复调用 `p.OpenFiles()`：
   - 有 DataDir → 永久缓存（生命周期内不变）
   - 无 DataDir → 30 秒后重新检测（覆盖用户登录场景）
   - 进程退出 → 自动清理

## 实测数据（WeChat 4.1.6.46 / 4.1.8.28）

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| 稳态内存 | ~1.2GB | ~50MB |
| 稳态 CPU | ~7% | ~0.6% |
| 进程检测 | 正常 | 正常 |
| 登录感知 | 实时 | ≤30 秒延迟 |

## 变更范围

仅修改 `internal/wechat/process/windows/detector.go`，1 个文件，+65 -11 行。