### PR TITLE
feat: Action CLI, normalized proxy fields, and media path enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,81 @@
-# chatlog_alpha
+# chatlog-plus
 
-原 [chatlog](https://github.com/sjzar/chatlog) 项目的二开版本，导入自 [xiaofeng2042 的分支](https://github.com/xiaofeng2042/chatlog)，以防止上游删库后分支被自动删除。
+`chatlog-plus` 是基于原 [chatlog](https://github.com/sjzar/chatlog) 持续维护的增强版本。这个仓库的目标不是重新发明一套协议，而是在尽量保持原有 HTTP / MCP / CLI 用法不变的前提下，把真实微信 v4 场景里最容易断的链路补稳。
 
-未经修改的源代码在 [main 分支](https://github.com/CJYKK/chatlog_backup/tree/main)，本人不对代码中的任何内容负责。
+目前这条增强线主要解决 4 类问题：
 
-感谢 [wx_key](https://github.com/ycccccccy/wx_key) 项目提供的解密源码
+- 给前端、脚本和调试面板提供可调用的 `action` 接口
+- 保持 `wx_key.dll` 在管理员模式下继续可用
+- 修复 `recordInfo`（笔记、合并转发）内部媒体的真实路径解析
+- 在不破坏旧字段的前提下，补充更适合后端消费的代理字段
 
-目前测试成功微信版本：4.1.5.30
+另外，当前仓库还包含一个本地自动化执行组件：
+
+- `pywechat_service`
+  - 用于驱动真实微信客户端 UI
+  - 提供图片/视频预取、合并聊天记录处理、笔记处理
+  - 提供讲述人开关与微信重启动作
+
+如果你是把它接到别的系统里，建议同时阅读：
+
+- 数据侧对外接口说明：[docs/external-api.md](./docs/external-api.md)
+- 本地 UI 自动化服务接口说明：[docs/pywechat-service-api.md](./docs/pywechat-service-api.md)
+
+原始基础代码可参考 [chatlog_backup](https://github.com/CJYKK/chatlog_backup/tree/main)。
+
+感谢 [wx_key](https://github.com/ycccccccy/wx_key) 项目提供的解密源码。
+
+目前测试通过的微信版本：`4.1.5.30`
 
 ## 重要提示
-请务必把dll文件放在exe可执行文件同目录下的lib/windows_x64文件夹下
-# 如发布页wx_key1.dll工作不正常，请尝试使用wx_key2.dll
 
-请务必使用重启获取秘钥，而不是直接点击解密数据
+- `wx_key.dll` 必须放在可执行文件同目录下的 `lib/windows_x64` 中
+- 如果发布页里的 `wx_key1.dll` 表现不稳定，可以换用 `wx_key2.dll`
+- 获取 Data Key 时，优先使用“重启并获取密钥”，不要直接点“解密数据”
 
 ## 更新日志
+
+### 2026年4月2日
+- **修复进程检测导致的严重内存泄漏**：
+  - **问题现象**：chatlog 运行时内存占用从正常的 40-60MB 飙升至 1.2GB，CPU 占用也显著升高。
+  - **根因定位**：`FindProcesses` 每 3 秒被 TUI 刷新循环调用。微信 V4 基于 Chromium 架构，会派生多个子进程（`--type=wxocr`、`--type=wxplayer`、`--type=wxutility` 等），每个子进程持有大量文件句柄。1月22日的提交将 `getProcessInfo`（内含 `p.OpenFiles()` 枚举所有句柄）的调用移到了 cmdline 过滤之前，导致每 3 秒对所有子进程执行昂贵的句柄枚举操作，内存持续累积。
+  - **修复方案**：
+    1. 使用 `--type=` 精确过滤 Chromium 子进程，在调用 `getProcessInfo` 之前拦截（微信主进程可能带 `--scene=` 等参数，但不会有 `--type=`）
+    2. 对主进程检测结果添加 PID 缓存，避免重复调用 `p.OpenFiles()`
+    3. 未登录（无 DataDir）的缓存 30 秒后自动重新检测，覆盖用户登录场景
+  - **效果**：稳态内存恢复至 ~50MB，稳态 CPU 恢复至 ~0.6%
+- **接口文档修正**：
+  - 修正 `set` 命令的 `--wal-enabled` 和 `--auto-decompress-debounce` flag 说明与实际代码一致
+
+### 2026年3月21日
+- **新增规范化代理字段**
+  - 普通多媒体消息会在 `contents` 中补充 `proxyType`、`proxyKey`、`proxyUrl`、`resolved`、`keySource`
+  - 笔记、合并转发等 `recordInfo` 消息会在 `contents.assets[]` 中给出逐项资产清单，适合后端直接消费
+- **补齐转发文件的 md5 恢复链**
+  - 对 `DataType=8` 且 `FullMD5` 为空的内部文件，新增 `DataTitle + DataSize -> hardlink -> md5` 的补偿解析
+  - 这样在文件已经落盘的机器上，这类内部文件也能回到统一的 `/file/<md5>` 代理形式
+- **继续保持兼容**
+  - 老字段没有删除，原有 `contents.md5`、`contents.path`、`recordInfo` 结构都还在
+  - 旧的后端拼接逻辑仍然可以作为降级方案，新系统则可以优先消费 `proxyUrl` 和 `assets[]`
+
+### 2026年3月20日
+- **补上可调用的 action 接口**
+  - 新增 `chatlog.exe action ...`，标准输出为 JSON Lines，方便前端、脚本和调试工具调用
+  - 同时补齐了账号状态输出、历史配置回填，以及重启取 key 时的上下文延续
+- **把 key 获取链路收稳**
+  - `wx_key.dll` 支持多路径定位，继续兼容管理员模式
+  - Data Key 获取流程做了优先级收敛，减少重启取 key 时的误判分支
+- **修复 recordInfo 内部媒体的代理路径**
+  - 笔记、合并转发里的 `video`、`file` 不再误走普通聊天路径
+  - 现在会根据 v4 hardlink 的 `type`、`dir1`、`dir2`、`extra_buffer` 还原 `Rec` 目录下的真实媒体位置
+  - 笔记 `.htm` 包体也已经能映射到正确的 `Dat` 路径
+  - 图片查找补齐了多种常见落盘形态，包括无后缀、`.jpg`、`.png`、`.gif`、`.bmp`、`_t`、`.dat`
+- **对外协议保持原样**
+  - 继续使用原版风格的代理入口：
+    - `/image/<md5>`
+    - `/video/<md5>`
+    - `/file/<md5>`
+  - 是否已经下载到本地，不再作为是否生成链接的前置条件；下载态交给下游自己处理
 
 ### 2026年1月25日
 - **CI/CD 优化**：

--- a/cmd/chatlog/cmd_action.go
+++ b/cmd/chatlog/cmd_action.go
@@ -1,0 +1,339 @@
+package chatlog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/sjzar/chatlog/internal/chatlog"
+)
+
+type actionEvent struct {
+	Type      string      `json:"type"`
+	Action    string      `json:"action,omitempty"`
+	Stage     string      `json:"stage,omitempty"`
+	Message   string      `json:"message,omitempty"`
+	ErrorCode string      `json:"error_code,omitempty"`
+	Data      interface{} `json:"data,omitempty"`
+	Timestamp string      `json:"timestamp"`
+}
+
+func emitActionEvent(eventType, action, stage, message, errorCode string, data interface{}) {
+	payload := actionEvent{
+		Type:      eventType,
+		Action:    action,
+		Stage:     stage,
+		Message:   message,
+		ErrorCode: errorCode,
+		Data:      data,
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "{\"type\":\"error\",\"message\":\"marshal action event failed: %v\",\"timestamp\":\"%s\"}\n", err, time.Now().Format(time.RFC3339))
+		return
+	}
+	fmt.Fprintln(os.Stdout, string(b))
+}
+
+func init() {
+	rootCmd.AddCommand(actionCmd)
+
+	actionCmd.AddCommand(actionStatusCmd)
+	actionCmd.AddCommand(actionListAccountsCmd)
+	actionCmd.AddCommand(actionGetImageKeyCmd)
+	actionCmd.AddCommand(actionRestartAndGetKeyCmd)
+	actionCmd.AddCommand(actionDecompressCmd)
+	actionCmd.AddCommand(actionStartHTTPCmd)
+	actionCmd.AddCommand(actionStartAutoDecompressCmd)
+	actionCmd.AddCommand(actionSetCmd)
+	actionCmd.AddCommand(actionSwitchAccountCmd)
+
+	addTargetFlags(actionStatusCmd)
+	addTargetFlags(actionGetImageKeyCmd)
+	addTargetFlags(actionRestartAndGetKeyCmd)
+	addTargetFlags(actionDecompressCmd)
+	addTargetFlags(actionStartHTTPCmd)
+	addTargetFlags(actionStartAutoDecompressCmd)
+	addTargetFlags(actionSwitchAccountCmd)
+
+	actionSetCmd.Flags().StringVar(&setHTTPAddr, "http-addr", "", "http listen addr")
+	actionSetCmd.Flags().StringVar(&setWorkDir, "work-dir", "", "work dir")
+	actionSetCmd.Flags().StringVar(&setDataKey, "data-key", "", "data key")
+	actionSetCmd.Flags().StringVar(&setImageKey, "image-key", "", "image key")
+	actionSetCmd.Flags().StringVar(&setDataDir, "data-dir", "", "data dir")
+	actionSetCmd.Flags().BoolVar(&setWalEnabled, "wal-enabled", false, "enable wal")
+	actionSetCmd.Flags().BoolVar(&setWalEnabledProvided, "set-wal-enabled", false, "apply wal enabled flag")
+	actionSetCmd.Flags().IntVar(&setAutoDecompressDebounce, "auto-decompress-debounce", 0, "auto decompress debounce ms")
+	actionSetCmd.Flags().BoolVar(&setAutoDecompressDebounceProvided, "set-auto-decompress-debounce", false, "apply auto decompress debounce")
+}
+
+var (
+	actionPID     int
+	actionHistory string
+
+	setHTTPAddr                       string
+	setWorkDir                        string
+	setDataKey                        string
+	setImageKey                       string
+	setDataDir                        string
+	setWalEnabled                     bool
+	setWalEnabledProvided             bool
+	setAutoDecompressDebounce         int
+	setAutoDecompressDebounceProvided bool
+)
+
+var actionCmd = &cobra.Command{
+	Use:   "action",
+	Short: "前端可调用的动作接口",
+}
+
+var actionStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "输出当前状态",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "status", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		if err := m.SelectAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "status", "select_account_failed", err.Error(), "select_account_failed", nil)
+			return
+		}
+		emitActionEvent("success", "status", "completed", "已输出当前状态", "", m.Snapshot())
+	},
+}
+
+var actionListAccountsCmd = &cobra.Command{
+	Use:   "list-accounts",
+	Short: "列出运行中与历史账号",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "list-accounts", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		emitActionEvent("success", "list-accounts", "completed", "已输出账号列表", "", m.ListAccounts())
+	},
+}
+
+var actionGetImageKeyCmd = &cobra.Command{
+	Use:   "get-image-key",
+	Short: "获取图片解压密钥",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "get-image-key", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		if err := m.SelectAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "get-image-key", "select_account_failed", err.Error(), "select_account_failed", nil)
+			return
+		}
+
+		emitActionEvent("action_started", "get-image-key", "starting", "开始获取图片解压密钥", "", m.Snapshot())
+		err = m.GetImageKeyWithStatus(func(message string) {
+			emitActionEvent("state", "get-image-key", "progress", message, "", nil)
+		})
+		if err != nil {
+			emitActionEvent("error", "get-image-key", "failed", err.Error(), "get_image_key_failed", nil)
+			return
+		}
+		emitActionEvent("success", "get-image-key", "completed", "已获取图片解压密钥", "", m.Snapshot())
+	},
+}
+
+var actionRestartAndGetKeyCmd = &cobra.Command{
+	Use:   "restart-and-get-key",
+	Short: "重启微信并获取解压密钥",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "restart-and-get-key", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		if err := m.SelectAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "restart-and-get-key", "select_account_failed", err.Error(), "select_account_failed", nil)
+			return
+		}
+
+		emitActionEvent("action_started", "restart-and-get-key", "starting", "开始重启微信并获取解压密钥", "", m.Snapshot())
+		err = m.RestartAndGetDataKey(func(message string) {
+			emitActionEvent("state", "restart-and-get-key", "progress", message, "", nil)
+		})
+		if err != nil {
+			emitActionEvent("error", "restart-and-get-key", "failed", err.Error(), "restart_and_get_key_failed", nil)
+			return
+		}
+		emitActionEvent("success", "restart-and-get-key", "completed", "已获取解压密钥", "", m.Snapshot())
+	},
+}
+
+var actionDecompressCmd = &cobra.Command{
+	Use:   "decompress-data",
+	Short: "解压聊天数据",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "decompress-data", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		if err := m.SelectAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "decompress-data", "select_account_failed", err.Error(), "select_account_failed", nil)
+			return
+		}
+
+		emitActionEvent("action_started", "decompress-data", "starting", "开始解压数据", "", m.Snapshot())
+		if err := m.DecryptDBFiles(); err != nil {
+			emitActionEvent("error", "decompress-data", "failed", err.Error(), "decompress_failed", nil)
+			return
+		}
+		emitActionEvent("success", "decompress-data", "completed", "数据解压完成", "", m.Snapshot())
+	},
+}
+
+var actionStartHTTPCmd = &cobra.Command{
+	Use:   "start-http",
+	Short: "启动 HTTP 服务并保持运行",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "start-http", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		if err := m.SelectAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "start-http", "select_account_failed", err.Error(), "select_account_failed", nil)
+			return
+		}
+
+		emitActionEvent("action_started", "start-http", "starting", "正在启动 HTTP 服务", "", m.Snapshot())
+		if err := m.StartService(); err != nil {
+			emitActionEvent("error", "start-http", "failed", err.Error(), "start_http_failed", nil)
+			return
+		}
+		emitActionEvent("success", "start-http", "running", "HTTP 服务已启动，进程保持运行中", "", m.Snapshot())
+
+		waitForSignal(func() {
+			if err := m.StopService(); err != nil {
+				log.Err(err).Msg("stop http service failed")
+			}
+		})
+	},
+}
+
+var actionStartAutoDecompressCmd = &cobra.Command{
+	Use:   "start-auto-decompress",
+	Short: "启动自动解压并保持运行",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "start-auto-decompress", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		if err := m.SelectAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "start-auto-decompress", "select_account_failed", err.Error(), "select_account_failed", nil)
+			return
+		}
+
+		emitActionEvent("action_started", "start-auto-decompress", "starting", "正在启动自动解压", "", m.Snapshot())
+		if err := m.StartAutoDecrypt(); err != nil {
+			emitActionEvent("error", "start-auto-decompress", "failed", err.Error(), "start_auto_decompress_failed", nil)
+			return
+		}
+		emitActionEvent("success", "start-auto-decompress", "running", "自动解压已启动，进程保持运行中", "", m.Snapshot())
+
+		waitForSignal(func() {
+			if err := m.StopAutoDecrypt(); err != nil {
+				log.Err(err).Msg("stop auto decompress failed")
+			}
+		})
+	},
+}
+
+var actionSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "设置运行配置",
+	Run: func(cmd *cobra.Command, args []string) {
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "set", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+		walEnabled := optionalBool(setWalEnabledProvided, setWalEnabled)
+		autoDecompressDebounce := optionalInt(setAutoDecompressDebounceProvided, setAutoDecompressDebounce)
+		if err := m.SetConfigValues(setHTTPAddr, setWorkDir, setDataKey, setImageKey, setDataDir, walEnabled, autoDecompressDebounce); err != nil {
+			emitActionEvent("error", "set", "failed", err.Error(), "set_failed", nil)
+			return
+		}
+		emitActionEvent("success", "set", "completed", "配置已更新", "", m.Snapshot())
+	},
+}
+
+var actionSwitchAccountCmd = &cobra.Command{
+	Use:   "switch-account",
+	Short: "切换账号",
+	Run: func(cmd *cobra.Command, args []string) {
+		if actionPID == 0 && actionHistory == "" {
+			emitActionEvent("error", "switch-account", "invalid_args", "必须提供 --pid 或 --history", "invalid_args", nil)
+			return
+		}
+		m, err := initActionManager()
+		if err != nil {
+			emitActionEvent("error", "switch-account", "init_failed", err.Error(), "init_failed", nil)
+			return
+		}
+
+		emitActionEvent("action_started", "switch-account", "starting", "开始切换账号", "", nil)
+		if err := m.SwitchToAccount(actionPID, actionHistory); err != nil {
+			emitActionEvent("error", "switch-account", "failed", err.Error(), "switch_account_failed", nil)
+			return
+		}
+		emitActionEvent("success", "switch-account", "completed", "账号切换完成", "", m.Snapshot())
+	},
+}
+
+func addTargetFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&actionPID, "pid", 0, "target wechat pid")
+	cmd.Flags().StringVar(&actionHistory, "history", "", "target history account")
+}
+
+func initActionManager() (*chatlog.Manager, error) {
+	m := chatlog.New()
+	if err := m.InitAction(""); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func waitForSignal(cleanup func()) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-ctx.Done()
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+func optionalBool(enabled bool, value bool) *bool {
+	if !enabled {
+		return nil
+	}
+	ret := value
+	return &ret
+}
+
+func optionalInt(enabled bool, value int) *int {
+	if !enabled {
+		return nil
+	}
+	ret := value
+	return &ret
+}

--- a/docs/external-api.md
+++ b/docs/external-api.md
@@ -1,0 +1,272 @@
+# chatlog-plus 对外接口文档
+
+> 以真实源码行为为准 | 更新：2026-04-02
+
+---
+
+## 一、能力总览
+
+| 能力 | 入口 | 适合场景 |
+|---|---|---|
+| HTTP API | `http://127.0.0.1:5030` | 后端系统拉取聊天记录、联系人、媒体代理链接 |
+| MCP | `/mcp` `/sse` `/message` | AI Agent 或支持 MCP 的客户端调用 |
+| Action CLI | `chatlog.exe action <命令>` | 本地脚本/调试面板控制账号、取 key、启动服务 |
+
+---
+
+## 二、Action CLI
+
+```powershell
+chatlog.exe action <命令> [flags]
+```
+
+所有命令输出均为 **JSON 事件流**（每行一个 JSON 对象），字段：`type` / `action` / `stage` / `message` / `code` / `data`。
+
+### 命令列表
+
+| 命令 | 说明 |
+|---|---|
+| `status` | 输出当前配置快照（workDir、dataDir、httpAddr、账号信息等） |
+| `list-accounts` | 列出本地所有可用的微信账号历史 |
+| `get-image-key` | 从运行中的微信进程提取图片解密密钥 |
+| `restart-and-get-key` | 重启微信并获取数据解压密钥（初始化流程） |
+| `decompress-data` | 解压聊天数据库（需先有 key） |
+| `start-http` | 启动 HTTP 服务，阻塞运行（Ctrl+C 优雅退出） |
+| `start-auto-decompress` | 启动自动解压守护进程，阻塞运行 |
+| `set` | 更新配置（httpAddr、workDir、dataKey、imageKey、dataDir、wal、autoDecompressDebounce） |
+| `switch-account` | 切换当前账号（需 `--pid` 或 `--history`） |
+
+### 通用 flags
+
+| Flag | 说明 |
+|---|---|
+| `--pid <int>` | 指定微信进程 PID |
+| `--history <string>` | 指定历史账号路径 |
+
+### `set` 命令 flags
+
+| Flag | 说明 |
+|---|---|
+| `--http-addr` | HTTP 监听地址，如 `127.0.0.1:5030` |
+| `--work-dir` | 工作目录 |
+| `--data-key` | 数据解压密钥 |
+| `--image-key` | 图片解密密钥 |
+| `--data-dir` | 微信数据目录 |
+| `--wal-enabled` + `--set-wal-enabled` | 开启 WAL 模式（需同时传 `--set-wal-enabled` 才生效） |
+| `--auto-decompress-debounce <int>` + `--set-auto-decompress-debounce` | 自动解压防抖间隔（毫秒，需同时传 flag 才生效） |
+
+### 典型启动链路
+
+```powershell
+chatlog.exe action status
+chatlog.exe action restart-and-get-key
+chatlog.exe action decompress-data
+chatlog.exe action start-http
+```
+
+---
+
+## 三、HTTP API
+
+默认监听：`http://127.0.0.1:5030`
+
+> **前提**：账号已选择、key 已配置、数据库已解密、HTTP 服务已启动。否则 `/api/v1/*` 路由会直接失败。
+
+### 3.0 健康检查
+
+```
+GET /health
+```
+
+返回 `{"status":"ok"}`。仅表示进程存活，不代表数据库可用。
+
+### 3.1 聊天记录
+
+```
+GET /api/v1/chatlog
+```
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `time` | 是 | 时间点或范围（见「时间格式」一节） |
+| `talker` | 否 | 对话方 wxid 或群 id，多个逗号分隔 |
+| `sender` | 否 | 群聊内发送者过滤，多个逗号分隔 |
+| `keyword` | 否 | 关键词过滤 |
+| `limit` | 否 | 最多返回条数 |
+| `offset` | 否 | 分页偏移 |
+| `format` | 否 | `json` / `csv` / `xlsx` / `chatlab` / 默认纯文本 |
+
+#### 时间格式
+
+| 形式 | 示例 |
+|---|---|
+| 年 | `2026` |
+| 月 | `2026-03` |
+| 日 | `2026-03-21` |
+| 分钟级时间点 | `2026-03-21/14:30` |
+| 日期范围 | `2026-03-01~2026-03-21` |
+| 分钟级范围 | `2026-03-21/14:30~2026-03-21/15:45` |
+
+> 含分钟时必须用 `/` 和 `:`，不支持空格或 `T` 分隔。
+
+#### `format=json` 消息字段
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `seq` | int64 | 唯一消息序列号，推荐作为主键 |
+| `time` | RFC3339 | 消息时间 |
+| `talker` | string | 会话 ID |
+| `talkerName` | string | 会话名 |
+| `isChatRoom` | bool | 是否群聊 |
+| `sender` | string | 发送人 wxid |
+| `senderName` | string | 发送人昵称 |
+| `isSelf` | bool | 是否自己发送 |
+| `type` | int64 | 主消息类型 |
+| `subType` | int64 | 子类型 |
+| `content` | string | 面向展示的文本内容，不适合机器解析 |
+| `contents` | object | 面向机器消费的结构化内容 |
+
+#### `contents` 媒体代理字段（规范化字段，优先使用）
+
+| 字段 | 说明 |
+|---|---|
+| `proxyType` | `image` / `video` / `voice` / `file` |
+| `proxyKey` | 代理所用 key（md5、path 或 voice server_id） |
+| `proxyUrl` | 推荐直接消费的代理地址，如 `/image/<md5>` |
+| `resolved` | 是否已得到可用代理 key |
+| `keySource` | key 来源，如 `contents.md5`、`contents.path`、`contents.voice` |
+
+#### `contents` 原始字段（降级用）
+
+| 字段 | 说明 |
+|---|---|
+| `md5` | 图片/视频/文件的 md5 |
+| `path` | 图片（type=3）或视频（type=43）的本地相对路径，由 PackedInfo 解析 |
+| `voice` | 语音消息 ServerID（type=34），配合 `/voice/<key>` 访问 |
+| `assets` | 笔记/合并转发展开后的媒体资产列表（已展平，含嵌套层级） |
+| `recordInfo` | 笔记/合并转发的原始结构（含 `datalist.dataitem[]`） |
+
+**消费优先级**：`contents.proxyUrl` → `contents.assets[].proxyUrl` → `contents.md5` / `contents.path` / `contents.voice`
+
+> `content` 字段仅用于展示，不适合作为媒体链接来源。
+
+#### 机器消费建议
+
+- 笔记（type=49/subType=24）和合并转发（type=49/subType=19）优先读 `contents.assets[]`
+- `assets[]` 已支持嵌套展平（合并转发内嵌套笔记时，嵌套层资产也会出现在外层 `assets[]` 中）
+- 生成链接 ≠ 文件已下载，最终以 HTTP GET 响应 200 为准
+
+### 3.2 联系人
+
+```
+GET /api/v1/contact
+```
+
+| 参数 | 说明 |
+|---|---|
+| `keyword` | 搜索关键词 |
+| `limit` / `offset` | 分页 |
+| `format` | `json` / `xlsx` / 默认文本 |
+
+`format=json` 返回 `{"items":[{"userName","alias","remark","nickName","isFriend"}]}`
+
+### 3.3 群聊
+
+```
+GET /api/v1/chatroom
+```
+
+| 参数 | 说明 |
+|---|---|
+| `keyword` / `limit` / `offset` / `format` | 同联系人 |
+
+`format=json` 返回 `{"items":[{"name","owner","users":[],"remark","nickName"}]}`
+
+### 3.4 最近会话
+
+```
+GET /api/v1/session
+```
+
+`format=json` 返回 `{"items":[{"userName","nOrder","nickName","content","nTime"}]}`
+
+### 3.5 朋友圈
+
+```
+GET /api/v1/sns
+```
+
+| 参数 | 说明 |
+|---|---|
+| `username` | 指定用户 |
+| `limit` / `offset` | 分页 |
+| `format` | `json` / `csv` / `xlsx` / `raw` / 默认文本 |
+
+`content_type` 归一值：`image` / `video` / `article` / `finder` / `text`
+
+### 3.6 数据库浏览（调试用）
+
+> 这组接口用于调试和内省，不建议业务系统作为稳定协议依赖。
+
+| 接口 | 说明 |
+|---|---|
+| `GET /api/v1/db` | 返回已解密数据库分组与文件列表 |
+| `GET /api/v1/db/tables?group=&file=` | 返回表名列表 |
+| `GET /api/v1/db/data?group=&file=&table=&keyword=&limit=&offset=&format=` | 分页查表数据 |
+| `GET /api/v1/db/query?group=&file=&sql=&format=` | 执行任意 SQL（不应暴露给不可信方） |
+| `POST /api/v1/cache/clear` | 清理媒体解密缓存文件 |
+
+---
+
+## 四、��体代理 API
+
+### 路由
+
+| 路由 | 说明 |
+|---|---|
+| `GET /image/*key` | 图片代理，支持 silk 解密和多后缀回退 |
+| `GET /video/*key` | 视频代理 |
+| `GET /file/*key` | 文件代理 |
+| `GET /voice/*key` | 语音代理，自动将 silk 转 mp3；失败则返回原始 silk（audio/silk） |
+| `GET /data/*path` | 底层文件出口，业务层不建议直接构造 |
+
+### key 类型
+
+`*key` 可以是 md5、相对路径、或逗号分隔的多候选。外部系统统一使用 md5 即可。
+
+### 可访问性判据
+
+正确判断一个 md5 是否已下载：对代理链接发送 GET 请求，跟随 302，最终响应 200 = 可访问。
+
+`?info=1` 或 `HEAD` 请求**不能**作为可访问性判据。
+
+### voice 特殊说明
+
+- type=34 语音消息，`contents.voice` 里存的是 `ServerID`（字符串形式的 int64）
+- 访问链接：`/voice/<ServerID>`
+- 服务端先尝试 silk 转 mp3（Content-Type: audio/mp3）；失败则回落到原始 silk（Content-Type: audio/silk）
+- 成功率取决于本地缓存是否存在，chatlog 不会主动下载
+
+---
+
+## 五、MCP
+
+> MCP 接口供 AI Agent 或支持 MCP 协议的客户端调用，路径在 `/mcp`（SSE: `/sse`，消息: `/message`）。
+
+所有 HTTP API 能力均已通过 MCP 工具暴露。
+
+**MCP vs HTTP 差异：**
+
+- HTTP 层有多层 fallback（多后缀候选、findImageByMD5、dat2img 解密）
+- MCP 层更直接（GetMedia → 绝对路径 → ReadFile），不等价
+- 同一 md5 通过 HTTP 能访问，通过 MCP 不一定等价成功
+- 业务系统消费媒体链接，**优先使用 HTTP 代理 API**，不建议依赖 MCP 做批量媒体访问
+
+---
+
+## 六、关键边界与注意事项
+
+1. **`path` 字段**：仅部分消息携带（图片 type=3、视频 type=43，需 PackedInfo 成功解析），是本地相对路径，可拼接成绝对路径直接读文件，也可用作 `/data/*path` 访问
+2. **嵌套媒体**：合并转发（subType=19）内嵌笔记（dataType=17）时，`assets[]` 会自动展平，嵌套层的媒体和外层一起出现，`index` 字段用点分隔标识层级，如 `2.1`
+3. **语音不自动下载**：chatlog 不触发微信重新下载语音，必须由 pyweixin 触发落盘后才可访问
+4. **文件访问先检查后读**：`/file/<md5>` 仅解密本地已有文件，文件未下载时返回 404

--- a/internal/chatlog/action.go
+++ b/internal/chatlog/action.go
@@ -1,0 +1,270 @@
+package chatlog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sjzar/chatlog/internal/chatlog/conf"
+	"github.com/sjzar/chatlog/internal/chatlog/ctx"
+	"github.com/sjzar/chatlog/internal/chatlog/database"
+	"github.com/sjzar/chatlog/internal/chatlog/http"
+	"github.com/sjzar/chatlog/internal/chatlog/wechat"
+	iwechat "github.com/sjzar/chatlog/internal/wechat"
+	"github.com/sjzar/chatlog/pkg/util"
+)
+
+type ActionAccount struct {
+	Source      string `json:"source"`
+	Account     string `json:"account"`
+	PID         uint32 `json:"pid,omitempty"`
+	DataDir     string `json:"data_dir,omitempty"`
+	WorkDir     string `json:"work_dir,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Platform    string `json:"platform,omitempty"`
+	Version     int    `json:"version,omitempty"`
+	FullVersion string `json:"full_version,omitempty"`
+	Current     bool   `json:"current"`
+}
+
+type ActionStatus struct {
+	Account                string `json:"account"`
+	PID                    int    `json:"pid"`
+	Status                 string `json:"status"`
+	ExePath                string `json:"exe_path"`
+	Platform               string `json:"platform"`
+	Version                int    `json:"version"`
+	FullVersion            string `json:"full_version"`
+	DataDir                string `json:"data_dir"`
+	WorkDir                string `json:"work_dir"`
+	DataKey                string `json:"data_key"`
+	ImageKey               string `json:"image_key"`
+	HTTPEnabled            bool   `json:"http_enabled"`
+	HTTPAddr               string `json:"http_addr"`
+	AutoDecompress         bool   `json:"auto_decompress"`
+	WalEnabled             bool   `json:"wal_enabled"`
+	AutoDecompressDebounce int    `json:"auto_decompress_debounce"`
+}
+
+func (m *Manager) InitAction(configPath string) error {
+	var err error
+	m.ctx, err = ctx.New(configPath)
+	if err != nil {
+		return err
+	}
+
+	m.wechat = wechat.NewService(m.ctx)
+	m.db = database.NewService(m.ctx)
+	m.http = http.NewService(m.ctx, m.db)
+
+	m.ctx.WeChatInstances = m.loadWeChatInstances()
+	if m.ctx.Current == nil && len(m.ctx.WeChatInstances) > 0 {
+		m.ctx.SwitchCurrent(m.ctx.WeChatInstances[0])
+	} else {
+		m.ctx.Refresh()
+	}
+
+	return nil
+}
+
+func (m *Manager) EnsureCurrentAccount() error {
+	if m.ctx == nil {
+		return fmt.Errorf("context not initialized")
+	}
+	if m.ctx.Current != nil {
+		return nil
+	}
+	m.ctx.WeChatInstances = m.loadWeChatInstances()
+	if len(m.ctx.WeChatInstances) == 0 {
+		return fmt.Errorf("未检测到微信进程")
+	}
+	m.ctx.SwitchCurrent(m.ctx.WeChatInstances[0])
+	return nil
+}
+
+func (m *Manager) SelectAccount(pid int, history string) error {
+	if pid != 0 {
+		for _, ins := range m.loadWeChatInstances() {
+			if int(ins.PID) == pid {
+				m.ctx.SwitchCurrent(ins)
+				return nil
+			}
+		}
+		return fmt.Errorf("未找到 PID=%d 的微信进程", pid)
+	}
+
+	if history != "" {
+		if _, ok := m.ctx.History[history]; !ok {
+			return fmt.Errorf("未找到历史账号 %s", history)
+		}
+		m.ctx.SwitchHistory(history)
+		return nil
+	}
+
+	return m.EnsureCurrentAccount()
+}
+
+func (m *Manager) Snapshot() ActionStatus {
+	m.ctx.Refresh()
+	history, ok := m.ctx.History[m.ctx.Account]
+	if !ok {
+		history = conf.ProcessConfig{}
+	}
+
+	dataDir := firstNonEmpty(m.ctx.DataDir, history.DataDir)
+	workDir := firstNonEmpty(m.ctx.WorkDir, history.WorkDir)
+	if workDir == "" && m.ctx.Account != "" {
+		workDir = util.DefaultWorkDir(m.ctx.Account)
+	}
+
+	httpAddr := firstNonEmpty(m.ctx.HTTPAddr, history.HTTPAddr)
+	if httpAddr == "" {
+		httpAddr = m.ctx.GetHTTPAddr()
+	}
+
+	dataKey := firstNonEmpty(m.ctx.DataKey, history.DataKey)
+	imageKey := firstNonEmpty(m.ctx.ImgKey, history.ImgKey)
+
+	return ActionStatus{
+		Account:                m.ctx.Account,
+		PID:                    m.ctx.PID,
+		Status:                 m.ctx.Status,
+		ExePath:                m.ctx.ExePath,
+		Platform:               m.ctx.Platform,
+		Version:                m.ctx.Version,
+		FullVersion:            m.ctx.FullVersion,
+		DataDir:                dataDir,
+		WorkDir:                workDir,
+		DataKey:                dataKey,
+		ImageKey:               imageKey,
+		HTTPEnabled:            m.ctx.HTTPEnabled,
+		HTTPAddr:               httpAddr,
+		AutoDecompress:         m.ctx.AutoDecrypt,
+		WalEnabled:             m.ctx.WalEnabled,
+		AutoDecompressDebounce: m.ctx.AutoDecryptDebounce,
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (m *Manager) ListAccounts() []ActionAccount {
+	instances := m.loadWeChatInstances()
+	ret := make([]ActionAccount, 0, len(instances)+len(m.ctx.History))
+
+	for _, ins := range instances {
+		ret = append(ret, ActionAccount{
+			Source:      "process",
+			Account:     ins.Name,
+			PID:         ins.PID,
+			DataDir:     ins.DataDir,
+			Status:      ins.Status,
+			Platform:    ins.Platform,
+			Version:     ins.Version,
+			FullVersion: ins.FullVersion,
+			Current:     m.ctx.Current != nil && m.ctx.Current.PID == ins.PID,
+		})
+	}
+
+	for account, hist := range m.ctx.History {
+		ret = append(ret, ActionAccount{
+			Source:      "history",
+			Account:     account,
+			DataDir:     hist.DataDir,
+			WorkDir:     hist.WorkDir,
+			Platform:    hist.Platform,
+			Version:     hist.Version,
+			FullVersion: hist.FullVersion,
+			Current:     m.ctx.Current == nil && m.ctx.DataDir != "" && m.ctx.DataDir == hist.DataDir,
+		})
+	}
+
+	return ret
+}
+
+func (m *Manager) GetImageKeyWithStatus(onStatus func(string)) error {
+	if err := m.EnsureCurrentAccount(); err != nil {
+		return err
+	}
+	if onStatus != nil {
+		onStatus("正在准备图片密钥扫描...")
+	}
+	ctx := context.WithValue(context.Background(), "status_callback", onStatus)
+	if _, err := m.ctx.Current.GetImageKey(ctx); err != nil {
+		return err
+	}
+	m.ctx.Refresh()
+	m.ctx.UpdateConfig()
+	return nil
+}
+
+func (m *Manager) SetDataKey(key string) error {
+	if m.ctx == nil {
+		return fmt.Errorf("context not initialized")
+	}
+	m.ctx.SetDataKey(key)
+	return nil
+}
+
+func (m *Manager) SetConfigValues(httpAddr, workDir, dataKey, imageKey, dataDir string, walEnabled *bool, autoDecompressDebounce *int) error {
+	if httpAddr != "" {
+		if err := m.SetHTTPAddr(httpAddr); err != nil {
+			return err
+		}
+	}
+	if workDir != "" {
+		m.ctx.SetWorkDir(workDir)
+	}
+	if dataKey != "" {
+		if err := m.SetDataKey(dataKey); err != nil {
+			return err
+		}
+	}
+	if imageKey != "" {
+		m.ctx.SetImgKey(imageKey)
+	}
+	if dataDir != "" {
+		m.ctx.SetDataDir(dataDir)
+	}
+	if walEnabled != nil {
+		m.ctx.SetWalEnabled(*walEnabled)
+	}
+	if autoDecompressDebounce != nil {
+		m.ctx.SetAutoDecryptDebounce(*autoDecompressDebounce)
+	}
+	return nil
+}
+
+func (m *Manager) SwitchToAccount(pid int, history string) error {
+	if pid != 0 {
+		var target *iwechat.Account
+		for _, ins := range m.loadWeChatInstances() {
+			if int(ins.PID) == pid {
+				target = ins
+				break
+			}
+		}
+		if target == nil {
+			return fmt.Errorf("未找到 PID=%d 的微信进程", pid)
+		}
+		return m.Switch(target, "")
+	}
+
+	if history == "" {
+		return fmt.Errorf("缺少切换目标")
+	}
+	if _, ok := m.ctx.History[history]; !ok {
+		return fmt.Errorf("未找到历史账号 %s", history)
+	}
+	return m.Switch(nil, history)
+}
+
+func (m *Manager) HistoryConfig(account string) (conf.ProcessConfig, bool) {
+	hist, ok := m.ctx.History[account]
+	return hist, ok
+}

--- a/internal/chatlog/app.go
+++ b/internal/chatlog/app.go
@@ -98,16 +98,16 @@ func (a *App) Stop() {
 }
 
 func (a *App) updateMenuItemsState() {
-	// 查找并更新自动解密菜单项
+	// 查找并更新自动解压菜单项
 	for _, item := range a.menu.GetItems() {
-		// 更新自动解密菜单项
+		// 更新自动解压菜单项
 		if item.Index == 6 {
 			if a.ctx.AutoDecrypt {
-				item.Name = "停止自动解密"
-				item.Description = "停止监控数据目录更新，不再自动解密新增数据"
+				item.Name = "停止自动解压"
+				item.Description = "停止监控数据目录更新，不再自动解压新增数据"
 			} else {
-				item.Name = "开启自动解密"
-				item.Description = "监控数据目录更新，自动解密新增数据"
+				item.Name = "开启自动解压"
+				item.Description = "监控数据目录更新，自动解压新增数据"
 			}
 		}
 
@@ -148,6 +148,7 @@ func (a *App) refresh() {
 				// 获取微信实例
 				instances, err := a.m.wechat.GetWeChatInstancesWithError()
 				processErr = err
+				instances = hydrateAccountsFromHistory(instances, a.ctx.History, a.ctx.Account)
 				if err == nil && len(instances) > 0 {
 					// 找到微信进程，设置第一个为当前账号
 					a.ctx.SwitchCurrent(instances[0])
@@ -210,7 +211,7 @@ func (a *App) refresh() {
 				if sender == "" {
 					sender = session.UserName
 				}
-			a.footer.UpdateLatestMessage(sender, session.NTime.Format("15:04:05"), session.Content)
+				a.footer.UpdateLatestMessage(sender, session.NTime.Format("15:04:05"), session.Content)
 			}
 
 			a.Draw()
@@ -319,29 +320,29 @@ func (a *App) initMenu() {
 
 	decryptData := &menu.Item{
 		Index:       4,
-		Name:        "解密数据",
-		Description: "解密数据文件",
+		Name:        "解压数据",
+		Description: "解压数据文件",
 		Selected: func(i *menu.Item) {
-			// 创建一个没有按钮的模态框，显示"解密中..."
+			// 创建一个没有按钮的模态框，显示"解压中..."
 			modal := tview.NewModal().
-				SetText("解密中...")
+				SetText("解压中...")
 
 			a.mainPages.AddPage("modal", modal, true, true)
 			a.SetFocus(modal)
 
-			// 在后台执行解密操作
+			// 在后台执行解压操作
 			go func() {
-				// 执行解密
+				// 执行解压
 				err := a.m.DecryptDBFiles()
 
 				// 在主线程中更新UI
 				a.QueueUpdateDraw(func() {
 					if err != nil {
-						// 解密失败
-						modal.SetText("解密失败: " + err.Error())
+						// 解压失败
+						modal.SetText("解压失败: " + err.Error())
 					} else {
-						// 解密成功
-						modal.SetText("解密数据成功")
+						// 解压成功
+						modal.SetText("解压数据成功")
 					}
 
 					// 添加确认按钮
@@ -431,19 +432,19 @@ func (a *App) initMenu() {
 
 	autoDecrypt := &menu.Item{
 		Index:       6,
-		Name:        "开启自动解密",
-		Description: "自动解密新增的数据文件",
+		Name:        "开启自动解压",
+		Description: "自动解压新增的数据文件",
 		Selected: func(i *menu.Item) {
 			modal := tview.NewModal()
 
-			// 根据当前自动解密状态执行不同操作
+			// 根据当前自动解压状态执行不同操作
 			if !a.ctx.AutoDecrypt {
-				// 自动解密未开启，开启自动解密
-				modal.SetText("正在开启自动解密...")
+				// 自动解压未开启，开启自动解压
+				modal.SetText("正在开启自动解压...")
 				a.mainPages.AddPage("modal", modal, true, true)
 				a.SetFocus(modal)
 
-				// 在后台开启自动解密
+				// 在后台开启自动解压
 				go func() {
 					err := a.m.StartAutoDecrypt()
 
@@ -451,10 +452,10 @@ func (a *App) initMenu() {
 					a.QueueUpdateDraw(func() {
 						if err != nil {
 							// 开启失败
-							modal.SetText("开启自动解密失败: " + err.Error())
+							modal.SetText("开启自动解压失败: " + err.Error())
 						} else {
 							// 开启成功
-							modal.SetText("已开启自动解密")
+							modal.SetText("已开启自动解压")
 						}
 
 						// 更改菜单项名称
@@ -469,12 +470,12 @@ func (a *App) initMenu() {
 					})
 				}()
 			} else {
-				// 自动解密已开启，停止自动解密
-				modal.SetText("正在停止自动解密...")
+				// 自动解压已开启，停止自动解压
+				modal.SetText("正在停止自动解压...")
 				a.mainPages.AddPage("modal", modal, true, true)
 				a.SetFocus(modal)
 
-				// 在后台停止自动解密
+				// 在后台停止自动解压
 				go func() {
 					err := a.m.StopAutoDecrypt()
 
@@ -482,10 +483,10 @@ func (a *App) initMenu() {
 					a.QueueUpdateDraw(func() {
 						if err != nil {
 							// 停止失败
-							modal.SetText("停止自动解密失败: " + err.Error())
+							modal.SetText("停止自动解压失败: " + err.Error())
 						} else {
 							// 停止成功
-							modal.SetText("已停止自动解密")
+							modal.SetText("已停止自动解压")
 						}
 
 						// 更改菜单项名称
@@ -552,17 +553,17 @@ func (a *App) settingSelected(i *menu.Item) {
 		},
 		{
 			name:        "设置工作目录",
-			description: "配置数据解密后的存储目录",
+			description: "配置数据解压后的存储目录",
 			action:      a.settingWorkDir,
 		},
 		{
 			name:        "设置数据密钥",
-			description: "配置数据解密密钥",
+			description: "配置数据解压密钥",
 			action:      a.settingDataKey,
 		},
 		{
 			name:        "设置图片密钥",
-			description: "配置图片解密密钥",
+			description: "配置图片解压密钥",
 			action:      a.settingImgKey,
 		},
 		{
@@ -576,8 +577,8 @@ func (a *App) settingSelected(i *menu.Item) {
 			action:      a.settingWalEnabled,
 		},
 		{
-			name:        "设置自动解密去抖",
-			description: "配置自动解密触发间隔(ms)",
+			name:        "设置自动解压去抖",
+			description: "配置自动解压触发间隔(ms)",
 			action:      a.settingAutoDecryptDebounce,
 		},
 	}
@@ -765,7 +766,7 @@ func (a *App) settingWalEnabled() {
 }
 
 func (a *App) settingAutoDecryptDebounce() {
-	formView := form.NewForm("设置自动解密去抖")
+	formView := form.NewForm("设置自动解压去抖")
 
 	tempDebounceText := ""
 	if a.ctx.AutoDecryptDebounce > 0 {
@@ -817,7 +818,7 @@ func (a *App) selectAccountSelected(i *menu.Item) {
 	subMenu := menu.NewSubMenu("切换账号")
 
 	// 添加微信进程
-	instances := a.m.wechat.GetWeChatInstances()
+	instances := hydrateAccountsFromHistory(a.m.wechat.GetWeChatInstances(), a.ctx.History, a.ctx.Account)
 	if len(instances) > 0 {
 		// 添加实例标题
 		subMenu.AddItem(&menu.Item{
@@ -870,13 +871,13 @@ func (a *App) selectAccountSelected(i *menu.Item) {
 
 								if err != nil {
 									// 切换失败
-								a.showError(fmt.Errorf("切换账号失败: %v", err))
-							} else {
-								// 切换成功
-								a.showInfo("切换账号成功")
-								// 更新菜单状态
-								a.updateMenuItemsState()
-							}
+									a.showError(fmt.Errorf("切换账号失败: %v", err))
+								} else {
+									// 切换成功
+									a.showInfo("切换账号成功")
+									// 更新菜单状态
+									a.updateMenuItemsState()
+								}
 							})
 						}()
 					}
@@ -943,13 +944,13 @@ func (a *App) selectAccountSelected(i *menu.Item) {
 
 								if err != nil {
 									// 切换失败
-								a.showError(fmt.Errorf("切换账号失败: %v", err))
-							} else {
-								// 切换成功
-								a.showInfo("切换账号成功")
-								// 更新菜单状态
-								a.updateMenuItemsState()
-							}
+									a.showError(fmt.Errorf("切换账号失败: %v", err))
+								} else {
+									// 切换成功
+									a.showInfo("切换账号成功")
+									// 更新菜单状态
+									a.updateMenuItemsState()
+								}
 							})
 						}()
 					}

--- a/internal/chatlog/ctx/context.go
+++ b/internal/chatlog/ctx/context.go
@@ -48,9 +48,9 @@ type Context struct {
 	HTTPAddr    string
 
 	// 自动解密
-	AutoDecrypt bool
-	LastSession time.Time
-	WalEnabled  bool
+	AutoDecrypt         bool
+	LastSession         time.Time
+	WalEnabled          bool
 	AutoDecryptDebounce int
 
 	// 当前选中的微信实例
@@ -268,6 +268,16 @@ func (c *Context) SetImgKey(key string) {
 	c.UpdateConfig()
 }
 
+func (c *Context) SetDataKey(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.DataKey == key {
+		return
+	}
+	c.DataKey = key
+	c.UpdateConfig()
+}
+
 func (c *Context) SetAutoDecrypt(enabled bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -302,18 +312,18 @@ func (c *Context) SetAutoDecryptDebounce(debounce int) {
 func (c *Context) UpdateConfig() {
 
 	pconf := conf.ProcessConfig{
-		Type:        "wechat",
-		Account:     c.Account,
-		Platform:    c.Platform,
-		Version:     c.Version,
-		FullVersion: c.FullVersion,
-		DataDir:     c.DataDir,
-		DataKey:     c.DataKey,
-		ImgKey:      c.ImgKey,
-		WorkDir:     c.WorkDir,
-		HTTPEnabled: c.HTTPEnabled,
-		HTTPAddr:    c.HTTPAddr,
-		WalEnabled:  c.WalEnabled,
+		Type:                "wechat",
+		Account:             c.Account,
+		Platform:            c.Platform,
+		Version:             c.Version,
+		FullVersion:         c.FullVersion,
+		DataDir:             c.DataDir,
+		DataKey:             c.DataKey,
+		ImgKey:              c.ImgKey,
+		WorkDir:             c.WorkDir,
+		HTTPEnabled:         c.HTTPEnabled,
+		HTTPAddr:            c.HTTPAddr,
+		WalEnabled:          c.WalEnabled,
 		AutoDecryptDebounce: c.AutoDecryptDebounce,
 	}
 

--- a/internal/chatlog/database/service.go
+++ b/internal/chatlog/database/service.go
@@ -121,6 +121,10 @@ func (s *Service) GetMedia(_type string, key string) (*model.Media, error) {
 	return s.db.GetMedia(_type, key)
 }
 
+func (s *Service) GetMediaByName(_type string, name string, size int64) (*model.Media, error) {
+	return s.db.GetMediaByName(_type, name, size)
+}
+
 func (s *Service) GetDecryptedDBs() (map[string][]string, error) {
 	if s.db == nil {
 		return nil, nil

--- a/internal/chatlog/http/proxy_enrichment.go
+++ b/internal/chatlog/http/proxy_enrichment.go
@@ -1,0 +1,111 @@
+package http
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/sjzar/chatlog/internal/model"
+)
+
+func (s *Service) enrichMessages(messages []*model.Message) {
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+
+		msg.RefreshProxyFields()
+		if msg.Contents == nil {
+			continue
+		}
+
+		recordInfo, ok := msg.Contents["recordInfo"].(*model.RecordInfo)
+		if !ok || recordInfo == nil {
+			continue
+		}
+
+		assets := s.enrichRecordInfo(recordInfo, "")
+		if len(assets) > 0 {
+			msg.Contents["assets"] = assets
+		}
+	}
+}
+
+func (s *Service) enrichRecordInfo(recordInfo *model.RecordInfo, prefix string) []model.RecordAsset {
+	if recordInfo == nil {
+		return nil
+	}
+
+	assets := make([]model.RecordAsset, 0, len(recordInfo.DataList.DataItems))
+	for i := range recordInfo.DataList.DataItems {
+		item := &recordInfo.DataList.DataItems[i]
+		index := strconv.Itoa(i)
+		if prefix != "" {
+			index = prefix + "." + index
+		}
+
+		s.enrichRecordDataItem(item)
+
+		if item.DataType == "17" && item.RecordXML != nil {
+			nestedAssets := s.enrichRecordInfo(&item.RecordXML.RecordInfo, index)
+			if len(nestedAssets) > 0 {
+				item.RecordXML.RecordInfo.Assets = nestedAssets
+				assets = append(assets, nestedAssets...)
+			}
+			continue
+		}
+
+		assets = append(assets, item.ToAsset(index))
+	}
+
+	recordInfo.Assets = assets
+	return assets
+}
+
+func (s *Service) enrichRecordDataItem(item *model.DataItem) {
+	if item == nil {
+		return
+	}
+
+	switch item.DataType {
+	case "2":
+		if item.FullMD5 != "" {
+			item.SetResolvedProxy("image", item.FullMD5, "fullmd5")
+		} else {
+			item.SetUnresolvedProxy("image", "missing_fullmd5")
+		}
+	case "4":
+		if item.FullMD5 != "" {
+			item.SetResolvedProxy("video", item.FullMD5, "fullmd5")
+		} else {
+			item.SetUnresolvedProxy("video", "missing_fullmd5")
+		}
+	case "8":
+		if item.FullMD5 != "" {
+			item.SetResolvedProxy("file", item.FullMD5, "fullmd5")
+			return
+		}
+
+		title := strings.TrimSpace(item.DataTitle)
+		if title == "" {
+			item.SetUnresolvedProxy("file", "missing_fullmd5")
+			return
+		}
+
+		size := item.DataSizeInt64()
+		media, err := s.db.GetMediaByName("file", title, size)
+		if err == nil && media != nil && media.Key != "" {
+			source := "hardlink_by_name"
+			if size > 0 {
+				source = "hardlink_by_name_size"
+			}
+			item.SetResolvedProxy("file", media.Key, source)
+			return
+		}
+
+		item.SetUnresolvedProxy("file", "missing_fullmd5")
+	case "3":
+		item.SetUnresolvedProxy("voice", "unsupported_record_voice")
+	default:
+		item.SetUnresolvedProxy("", "")
+	}
+}

--- a/internal/chatlog/http/route.go
+++ b/internal/chatlog/http/route.go
@@ -136,6 +136,7 @@ func (s *Service) handleChatlog(c *gin.Context) {
 
 	// Populate md5->path cache for media files
 	s.populateMD5PathCache(messages)
+	s.enrichMessages(messages)
 
 	switch strings.ToLower(q.Format) {
 	case "chatlab":
@@ -149,7 +150,7 @@ func (s *Service) handleChatlog(c *gin.Context) {
 				}
 			}
 		}
-		
+
 		chatLabData := model.ConvertToChatLab(messages, q.Talker, talkerName)
 		c.JSON(http.StatusOK, chatLabData)
 	case "csv":
@@ -513,7 +514,10 @@ func (s *Service) handleMedia(c *gin.Context, _type string) {
 			s.handleImageFile(c, filepath.Join(s.conf.GetDataDir(), media.Path))
 			return
 		default:
-			// For other types, keep the old redirect logic
+			if resolvedPath, err := s.findPath(_type, media.Path); err == nil {
+				c.Redirect(http.StatusFound, "/data/"+resolvedPath)
+				return
+			}
 			c.Redirect(http.StatusFound, "/data/"+media.Path)
 			return
 		}
@@ -532,9 +536,10 @@ func (s *Service) findPath(_type string, key string) (string, error) {
 	}
 	switch _type {
 	case "image":
-		for _, suffix := range []string{"_h.dat", ".dat", "_t.dat"} {
-			if _, err := os.Stat(absolutePath + suffix); err == nil {
-				return key + suffix, nil
+		for _, candidate := range s.imagePathCandidates(key) {
+			testPath := filepath.Join(s.conf.GetDataDir(), candidate)
+			if _, err := os.Stat(testPath); err == nil {
+				return candidate, nil
 			}
 		}
 	case "video":
@@ -622,27 +627,58 @@ func (s *Service) getMD5FromCache(md5 string) string {
 	return ""
 }
 
-// tryFindFileWithSuffixes tries to find a file with different suffixes
-// Priority: .dat (original) -> _h.dat (HD) -> _t.dat (thumbnail)
+func (s *Service) imagePathCandidates(basePath string) []string {
+	candidates := []string{basePath}
+	if filepath.Ext(basePath) != "" {
+		return candidates
+	}
+
+	candidates = append(candidates,
+		basePath+".jpg",
+		basePath+".png",
+		basePath+".gif",
+		basePath+".jpeg",
+		basePath+".bmp",
+		basePath+"_t",
+		basePath+"_t.jpg",
+		basePath+"_t.png",
+		basePath+"_t.gif",
+		basePath+"_t.jpeg",
+		basePath+"_t.bmp",
+		basePath+"_h.dat",
+		basePath+".dat",
+		basePath+"_t.dat",
+	)
+	return candidates
+}
+
+func (s *Service) resolveExistingImagePath(basePath string) string {
+	for _, candidate := range s.imagePathCandidates(basePath) {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// tryFindFileWithSuffixes tries common media suffixes for cached paths.
 func (s *Service) tryFindFileWithSuffixes(basePath string) string {
 	dataDir := s.conf.GetDataDir()
 
-	// Try different suffixes with priority: original -> HD -> thumbnail
-	suffixes := []string{".dat", "_h.dat", "_t.dat"}
-
-	for _, suffix := range suffixes {
-		testPath := filepath.Join(dataDir, basePath+suffix)
+	for _, candidate := range s.imagePathCandidates(basePath) {
+		testPath := filepath.Join(dataDir, candidate)
 		if _, err := os.Stat(testPath); err == nil {
-			log.Debug().Str("path", testPath).Str("suffix", suffix).Msg("Found file with suffix")
+			log.Debug().Str("path", testPath).Msg("Found image candidate")
 			return testPath
 		}
 	}
 
-	// Try without any suffix (might already have extension)
-	testPath := filepath.Join(dataDir, basePath)
-	if _, err := os.Stat(testPath); err == nil {
-		log.Debug().Str("path", testPath).Msg("Found file without suffix")
-		return testPath
+	for _, suffix := range []string{".mp4", "_thumb.jpg"} {
+		testPath := filepath.Join(dataDir, basePath+suffix)
+		if _, err := os.Stat(testPath); err == nil {
+			log.Debug().Str("path", testPath).Str("suffix", suffix).Msg("Found video candidate")
+			return testPath
+		}
 	}
 
 	log.Debug().Str("basePath", basePath).Msg("File not found with any suffix")
@@ -683,6 +719,10 @@ func (s *Service) populateMD5PathCache(messages []*model.Message) {
 
 // handleImageFile processes an image file, handling decryption if it's a .dat file or file without extension
 func (s *Service) handleImageFile(c *gin.Context, absolutePath string) {
+	if resolvedPath := s.resolveExistingImagePath(absolutePath); resolvedPath != "" {
+		absolutePath = resolvedPath
+	}
+
 	// Check if the file needs decryption (either .dat extension or no extension)
 	needsDecryption := strings.HasSuffix(strings.ToLower(absolutePath), ".dat") ||
 		filepath.Ext(absolutePath) == ""
@@ -978,7 +1018,7 @@ func (s *Service) handleGetDBTableData(c *gin.Context) {
 		s.exportData(c, data, format, table)
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, data)
 }
 
@@ -1050,16 +1090,16 @@ func (s *Service) exportData(c *gin.Context, data []map[string]interface{}, form
 				log.Error().Err(err).Msg("Failed to close excel file")
 			}
 		}()
-		
+
 		sheet := "Sheet1"
 		index, _ := f.NewSheet(sheet)
-		
+
 		// Write headers
 		for i, h := range headers {
 			cell, _ := excelize.CoordinatesToCellName(i+1, 1)
 			f.SetCellValue(sheet, cell, h)
 		}
-		
+
 		// Write data
 		for r, row := range data {
 			for cIdx, h := range headers {
@@ -1068,7 +1108,7 @@ func (s *Service) exportData(c *gin.Context, data []map[string]interface{}, form
 				f.SetCellValue(sheet, cell, val)
 			}
 		}
-		
+
 		f.SetActiveSheet(index)
 		c.Writer.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
 		c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.xlsx", filename))
@@ -1263,4 +1303,3 @@ func (s *Service) handleSNSRaw(c *gin.Context, username string, limit, offset in
 		c.Writer.Flush()
 	}
 }
-

--- a/internal/chatlog/instance_hydration.go
+++ b/internal/chatlog/instance_hydration.go
@@ -1,0 +1,76 @@
+package chatlog
+
+import (
+	"strings"
+
+	"github.com/sjzar/chatlog/internal/chatlog/conf"
+	iwechat "github.com/sjzar/chatlog/internal/wechat"
+)
+
+func (m *Manager) loadWeChatInstances() []*iwechat.Account {
+	instances := m.wechat.GetWeChatInstances()
+	return hydrateAccountsFromHistory(instances, m.ctx.History, m.ctx.Account)
+}
+
+func hydrateAccountsFromHistory(instances []*iwechat.Account, history map[string]conf.ProcessConfig, preferredAccount string) []*iwechat.Account {
+	if len(instances) == 0 {
+		return instances
+	}
+
+	hydrated := make([]*iwechat.Account, 0, len(instances))
+	for _, account := range instances {
+		if account == nil {
+			continue
+		}
+
+		copyAccount := *account
+		hydratedAccount := &copyAccount
+
+		if len(history) != 0 && strings.HasPrefix(hydratedAccount.Name, "未登录微信_") {
+			if candidate, ok := selectHistoryCandidate(history, preferredAccount, len(instances)); ok {
+				hydratedAccount.Name = candidate.Account
+				if hydratedAccount.DataDir == "" {
+					hydratedAccount.DataDir = candidate.DataDir
+				}
+				if hydratedAccount.Key == "" {
+					hydratedAccount.Key = candidate.DataKey
+				}
+				if hydratedAccount.ImgKey == "" {
+					hydratedAccount.ImgKey = candidate.ImgKey
+				}
+				if hydratedAccount.FullVersion == "" {
+					hydratedAccount.FullVersion = candidate.FullVersion
+				}
+				if hydratedAccount.Version == 0 {
+					hydratedAccount.Version = candidate.Version
+				}
+				if hydratedAccount.Platform == "" {
+					hydratedAccount.Platform = candidate.Platform
+				}
+				if hydratedAccount.Status == "" || hydratedAccount.Status == "offline" {
+					hydratedAccount.Status = "online"
+				}
+			}
+		}
+
+		hydrated = append(hydrated, hydratedAccount)
+	}
+
+	return hydrated
+}
+
+func selectHistoryCandidate(history map[string]conf.ProcessConfig, preferredAccount string, processCount int) (conf.ProcessConfig, bool) {
+	if preferredAccount != "" {
+		if candidate, ok := history[preferredAccount]; ok {
+			return candidate, true
+		}
+	}
+
+	if processCount == 1 && len(history) == 1 {
+		for _, candidate := range history {
+			return candidate, true
+		}
+	}
+
+	return conf.ProcessConfig{}, false
+}

--- a/internal/chatlog/manager.go
+++ b/internal/chatlog/manager.go
@@ -54,7 +54,7 @@ func (m *Manager) Run(configPath string) error {
 
 	m.http = http.NewService(m.ctx, m.db)
 
-	m.ctx.WeChatInstances = m.wechat.GetWeChatInstances()
+	m.ctx.WeChatInstances = m.loadWeChatInstances()
 	if len(m.ctx.WeChatInstances) >= 1 {
 		m.ctx.SwitchCurrent(m.ctx.WeChatInstances[0])
 	}
@@ -199,8 +199,10 @@ func (m *Manager) RestartAndGetDataKey(onStatus func(string)) error {
 
 	pid := m.ctx.Current.PID
 	exePath := m.ctx.Current.ExePath
+	previousAccount := m.ctx.Account
+	previousImgKey := m.ctx.ImgKey
+	previousDataDir := m.ctx.DataDir
 
-	// 1. Terminate the process
 	if onStatus != nil {
 		onStatus("正在结束微信进程...")
 	}
@@ -213,10 +215,9 @@ func (m *Manager) RestartAndGetDataKey(onStatus func(string)) error {
 		return fmt.Errorf("failed to kill process with PID %d: %w", pid, err)
 	}
 
-	// 2. Wait for the process to disappear
 	log.Info().Msg("Waiting for WeChat process to terminate...")
-	for i := 0; i < 10; i++ { // Wait for max 10 seconds
-		instances := m.wechat.GetWeChatInstances()
+	for i := 0; i < 10; i++ {
+		instances := m.loadWeChatInstances()
 		found := false
 		for _, inst := range instances {
 			if inst.PID == pid {
@@ -230,7 +231,6 @@ func (m *Manager) RestartAndGetDataKey(onStatus func(string)) error {
 		time.Sleep(1 * time.Second)
 	}
 
-	// 3. Restart WeChat
 	if onStatus != nil {
 		onStatus("正在重启微信...")
 	}
@@ -240,15 +240,13 @@ func (m *Manager) RestartAndGetDataKey(onStatus func(string)) error {
 		return fmt.Errorf("failed to restart WeChat: %w", err)
 	}
 
-	// 4. Wait for the new process to appear.
 	if onStatus != nil {
 		onStatus("正在等待新进程启动...")
 	}
 	log.Info().Msg("Waiting for new WeChat process to start...")
 	var newInstance *iwechat.Account
-	for i := 0; i < 30; i++ { // Wait for max 30 seconds
-		instances := m.wechat.GetWeChatInstances()
-		// Try to find a new instance. A new instance is one with a different PID.
+	for i := 0; i < 30; i++ {
+		instances := m.loadWeChatInstances()
 		for _, inst := range instances {
 			if inst.PID != pid && inst.ExePath == exePath {
 				newInstance = inst
@@ -266,19 +264,22 @@ func (m *Manager) RestartAndGetDataKey(onStatus func(string)) error {
 	}
 	log.Info().Msgf("Found new WeChat process with PID %d", newInstance.PID)
 
-	// 5. Switch to the new instance
+	if previousAccount != "" && !strings.HasPrefix(previousAccount, "未登录微信_") {
+		newInstance.Name = previousAccount
+	}
+	if previousImgKey != "" {
+		newInstance.ImgKey = previousImgKey
+	}
+	if previousDataDir != "" && newInstance.DataDir == "" {
+		newInstance.DataDir = previousDataDir
+	}
 	m.ctx.SwitchCurrent(newInstance)
 
-	// 6. Get the key
-	// 增加重试逻辑：微信刚启动时可能DLL未加载完成导致Hook失败，需要等待
 	log.Info().Msg("Getting key from new WeChat process...")
-
-	// 使用携带回调的 context
 	ctx := context.WithValue(context.Background(), "status_callback", onStatus)
+	ctx = context.WithValue(ctx, "prefer_data_key_only", true)
 
 	var key, imgKey string
-
-	// 初始化截止时间 (30秒)
 	deadline := time.Now().Add(30 * time.Second)
 
 	for {
@@ -286,37 +287,24 @@ func (m *Manager) RestartAndGetDataKey(onStatus func(string)) error {
 			onStatus("正在等待微信初始化...")
 		}
 
-		// 尝试获取密钥 (会尝试初始化DLL)
 		key, imgKey, err = m.ctx.Current.GetKey(ctx)
-
-		// 如果成功，跳出循环
-		// 注意：GetKey 成功意味着 Hook 安装成功且已经获取到了密钥
-		// 但实际上 DLL 模式下，Extract 会在 Hook 安装成功后阻塞轮询。
-		// 所以如果这里返回 nil，说明已经完成了整个流程。
 		if err == nil {
 			break
 		}
-
-		// 如果超时，且包含特定错误，则退出
 		if time.Now().After(deadline) {
 			return fmt.Errorf("获取密钥超时: %v", err)
 		}
 
-		// 检查错误类型，决定是否重试
-		// 如果是初始化失败（例如微信模块未加载），则重试
-		// 如果是 "wechat process not found" 等临时错误，也重试
-		// 如果是 pollKeys 内部的超时（30s），说明 Hook 成功但用户未操作，此时不应该重试，
-		// 但 pollKeys 内部超时会返回错误，这里会捕获。
-		// 不过 pollKeys 耗时 30s，如果走到这里说明已经等了 30s，外层 deadline 也会触发。
-		
-		// 只有快速失败（初始化错误）才需要 fast retry
 		log.Debug().Err(err).Msg("获取密钥尝试失败，准备重试")
-		
 		time.Sleep(1 * time.Second)
 	}
 
-	m.ctx.DataKey = key
-	m.ctx.ImgKey = imgKey
+	if key != "" {
+		m.ctx.DataKey = key
+	}
+	if imgKey != "" {
+		m.ctx.ImgKey = imgKey
+	}
 	m.ctx.Refresh()
 	m.ctx.UpdateConfig()
 
@@ -420,8 +408,6 @@ func (m *Manager) GetLatestSession() (*model.Session, error) {
 	return nil, nil
 }
 
-
-
 func (m *Manager) CommandKey(configPath string, pid int, force bool, showXorKey bool) (string, error) {
 
 	var err error
@@ -432,7 +418,7 @@ func (m *Manager) CommandKey(configPath string, pid int, force bool, showXorKey 
 
 	m.wechat = wechat.NewService(m.ctx)
 
-	m.ctx.WeChatInstances = m.wechat.GetWeChatInstances()
+	m.ctx.WeChatInstances = m.loadWeChatInstances()
 	if len(m.ctx.WeChatInstances) == 0 {
 		return "", fmt.Errorf("wechat process not found")
 	}
@@ -597,4 +583,3 @@ func (m *Manager) CommandHTTPServer(configPath string, cmdConf map[string]any) e
 
 	return m.http.ListenAndServe()
 }
-

--- a/internal/chatlog/wechat/service.go
+++ b/internal/chatlog/wechat/service.go
@@ -100,7 +100,8 @@ func (s *Service) GetDataKey(info *wechat.Account) (string, error) {
 		return "", fmt.Errorf("no WeChat instance selected")
 	}
 
-	key, _, err := info.GetKey(context.Background())
+	ctx := context.WithValue(context.Background(), "prefer_data_key_only", true)
+	key, _, err := info.GetKey(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/model/media_v4.go
+++ b/internal/model/media_v4.go
@@ -3,6 +3,7 @@ package model
 import (
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 type MediaV4 struct {
@@ -14,6 +15,7 @@ type MediaV4 struct {
 	Name         string `json:"name"`
 	Size         int64  `json:"size"`
 	ModifyTime   int64  `json:"modifyTime"`
+	HardLinkType int    `json:"-"`
 }
 
 func (m *MediaV4) Wrap() *Media {
@@ -21,19 +23,34 @@ func (m *MediaV4) Wrap() *Media {
 	var path string
 	switch m.Type {
 	case "image":
-		// Clean extra_buffer: extract only alphanumeric characters
-		extraBuffer := m.cleanExtraBuffer(m.ExtraBuffer)
-		if extraBuffer != "" {
-			// Path with Rec/{extra_buffer}: msg/attach/{Dir1}/{Dir2}/Rec/{extraBuffer}/Img/{Name}
-			path = filepath.Join("msg", "attach", m.Dir1, m.Dir2, "Rec", extraBuffer, "Img", m.Name)
+		extraParts := m.extraBufferParts()
+		if len(extraParts) > 0 {
+			path = filepath.Join("msg", "attach", m.Dir1, m.Dir2, "Rec", extraParts[0], "Img", m.Name)
 		} else {
-			// Fallback to old path format: msg/attach/{Dir1}/{Dir2}/Img/{Name}
 			path = filepath.Join("msg", "attach", m.Dir1, m.Dir2, "Img", m.Name)
 		}
 	case "video":
-		path = filepath.Join("msg", "video", m.Dir1, m.Name)
+		extraParts := m.extraBufferParts()
+		if m.HardLinkType == 5 && len(extraParts) > 0 {
+			path = filepath.Join("msg", "attach", m.Dir1, m.Dir2, "Rec", extraParts[0], "V", m.Name)
+		} else {
+			path = filepath.Join("msg", "video", m.Dir1, m.Name)
+		}
 	case "file":
-		path = filepath.Join("msg", "file", m.Dir1, m.Name)
+		extraParts := m.extraBufferParts()
+		if m.HardLinkType == 6 && len(extraParts) > 0 {
+			dirName := "F"
+			if filepath.Ext(m.Name) == "" {
+				dirName = "Dat"
+			}
+			if len(extraParts) > 1 {
+				path = filepath.Join("msg", "attach", m.Dir1, m.Dir2, "Rec", extraParts[0], dirName, extraParts[1], m.Name)
+			} else {
+				path = filepath.Join("msg", "attach", m.Dir1, m.Dir2, "Rec", extraParts[0], dirName, m.Name)
+			}
+		} else {
+			path = filepath.Join("msg", "file", m.Dir1, m.Name)
+		}
 	}
 
 	return &Media{
@@ -46,20 +63,24 @@ func (m *MediaV4) Wrap() *Media {
 	}
 }
 
-// cleanExtraBuffer extracts only alphanumeric characters from extra_buffer
-func (m *MediaV4) cleanExtraBuffer(extraBuffer string) string {
-	if extraBuffer == "" {
-		return ""
+// extraBufferParts extracts ASCII-like segments from extra_buffer.
+// v4 hardlink rows store record subdirectories and, for some files, nested indexes here.
+func (m *MediaV4) extraBufferParts() []string {
+	if m.ExtraBuffer == "" {
+		return nil
 	}
 
-	// Remove all non-alphanumeric characters
-	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
-	cleaned := re.ReplaceAllString(extraBuffer, "")
-
-	// Only return if we have meaningful content
-	if cleaned != "" {
-		return cleaned
+	re := regexp.MustCompile(`[a-zA-Z0-9]+`)
+	matches := re.FindAllString(m.ExtraBuffer, -1)
+	if len(matches) == 0 {
+		return nil
 	}
 
-	return ""
+	parts := make([]string, 0, len(matches))
+	for _, part := range matches {
+		if strings.TrimSpace(part) != "" {
+			parts = append(parts, part)
+		}
+	}
+	return parts
 }

--- a/internal/model/mediamessage.go
+++ b/internal/model/mediamessage.go
@@ -162,15 +162,16 @@ type RecordItem struct {
 
 // RecordInfo 表示聊天记录信息
 type RecordInfo struct {
-	XMLName       xml.Name `xml:"recordinfo"`
-	FromScene     string   `xml:"fromscene,omitempty"`
-	FavUsername   string   `xml:"favusername,omitempty"`
-	FavCreateTime string   `xml:"favcreatetime,omitempty"`
-	IsChatRoom    string   `xml:"isChatRoom,omitempty"`
-	Title         string   `xml:"title,omitempty"`
-	Desc          string   `xml:"desc,omitempty"`
-	Info          string   `xml:"info,omitempty"`
-	DataList      DataList `xml:"datalist,omitempty"`
+	XMLName       xml.Name      `xml:"recordinfo"`
+	FromScene     string        `xml:"fromscene,omitempty"`
+	FavUsername   string        `xml:"favusername,omitempty"`
+	FavCreateTime string        `xml:"favcreatetime,omitempty"`
+	IsChatRoom    string        `xml:"isChatRoom,omitempty"`
+	Title         string        `xml:"title,omitempty"`
+	Desc          string        `xml:"desc,omitempty"`
+	Info          string        `xml:"info,omitempty"`
+	DataList      DataList      `xml:"datalist,omitempty"`
+	Assets        []RecordAsset `json:"assets,omitempty" xml:"-"`
 }
 
 // DataList 表示数据列表
@@ -221,6 +222,14 @@ type DataItem struct {
 	// 套娃合并转发
 	DataTitle string     `xml:"datatitle,omitempty"`
 	RecordXML *RecordXML `xml:"recordxml,omitempty"`
+
+	// Normalized fields for downstream consumers.
+	MD5       string `json:"md5,omitempty" xml:"-"`
+	ProxyType string `json:"proxyType,omitempty" xml:"-"`
+	ProxyKey  string `json:"proxyKey,omitempty" xml:"-"`
+	ProxyURL  string `json:"proxyUrl,omitempty" xml:"-"`
+	Resolved  bool   `json:"resolved" xml:"-"`
+	KeySource string `json:"keySource,omitempty" xml:"-"`
 }
 
 type DataItemLocation struct {
@@ -264,17 +273,29 @@ func (r *RecordInfo) String(_type, title, host string) string {
 		switch item.DataType {
 		case "2":
 			// 图片
-			buf.WriteString(fmt.Sprintf("  ![图片](http://%s/image/%s)\n", host, item.FullMD5))
+			if item.ProxyURL != "" {
+				buf.WriteString(fmt.Sprintf("  ![图片](%s)\n", item.ProxyURL))
+			} else {
+				buf.WriteString(fmt.Sprintf("  ![图片](http://%s/image/%s)\n", host, item.FullMD5))
+			}
 		case "4":
 			//视频
-			buf.WriteString(fmt.Sprintf("  ![视频](http://%s/video/%s)\n", host, item.FullMD5))
+			if item.ProxyURL != "" {
+				buf.WriteString(fmt.Sprintf("  ![视频](%s)\n", item.ProxyURL))
+			} else {
+				buf.WriteString(fmt.Sprintf("  ![视频](http://%s/video/%s)\n", host, item.FullMD5))
+			}
 		case "8":
 			// 文件
 			// FIXME 笔记的第一条是 htm 数据，暂时跳过处理
 			if item.DataFmt == ".htm" {
 				continue
 			}
-			buf.WriteString(fmt.Sprintf("  [文件|%s](http://%s/file/%s)\n", item.DataTitle, host, item.FullMD5))
+			if item.ProxyURL != "" {
+				buf.WriteString(fmt.Sprintf("  [文件|%s](%s)\n", item.DataTitle, item.ProxyURL))
+			} else {
+				buf.WriteString(fmt.Sprintf("  [文件|%s](http://%s/file/%s)\n", item.DataTitle, host, item.FullMD5))
+			}
 		case "5":
 			// Link
 			buf.WriteString(fmt.Sprintf("  [链接|%s](%s)\n", item.DataTitle, item.Link))

--- a/internal/model/message.go
+++ b/internal/model/message.go
@@ -12,7 +12,7 @@ import (
 var Debug = false
 
 const (
-	WeChatV4       = "wechatv4"
+	WeChatV4 = "wechatv4"
 )
 
 const (
@@ -285,6 +285,7 @@ func (m *Message) ParseMediaInfo(data string) error {
 		}
 	}
 
+	m.RefreshProxyFields()
 	return nil
 }
 

--- a/internal/model/message_v4.go
+++ b/internal/model/message_v4.go
@@ -101,6 +101,7 @@ func (m *MessageV4) Wrap(talker string) *Message {
 		}
 	}
 
+	_m.RefreshProxyFields()
 	return _m
 }
 

--- a/internal/model/proxy.go
+++ b/internal/model/proxy.go
@@ -1,0 +1,190 @@
+package model
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type RecordAsset struct {
+	Index          string `json:"index"`
+	DataType       string `json:"dataType,omitempty"`
+	DataFmt        string `json:"dataFmt,omitempty"`
+	MessageType    int64  `json:"messageType"`
+	MessageSubType int64  `json:"messageSubType"`
+	Title          string `json:"title,omitempty"`
+	Content        string `json:"content,omitempty"`
+	SourceName     string `json:"sourceName,omitempty"`
+	SourceTime     string `json:"sourceTime,omitempty"`
+	Size           int64  `json:"size,omitempty"`
+	ProxyType      string `json:"proxyType,omitempty"`
+	ProxyKey       string `json:"proxyKey,omitempty"`
+	ProxyURL       string `json:"proxyUrl,omitempty"`
+	Resolved       bool   `json:"resolved"`
+	KeySource      string `json:"keySource,omitempty"`
+}
+
+func BuildProxyURL(proxyType, key string) string {
+	if proxyType == "" || key == "" {
+		return ""
+	}
+	return "/" + proxyType + "/" + url.PathEscape(key)
+}
+
+func (m *Message) RefreshProxyFields() {
+	if m.Contents == nil {
+		return
+	}
+
+	var proxyType string
+	var proxyKey string
+	var keySource string
+
+	switch m.Type {
+	case MessageTypeImage:
+		proxyType = "image"
+		if md5, _ := m.Contents["md5"].(string); md5 != "" {
+			proxyKey = md5
+			keySource = "contents.md5"
+		} else if path, _ := m.Contents["path"].(string); path != "" {
+			proxyKey = path
+			keySource = "contents.path"
+		}
+	case MessageTypeVoice:
+		proxyType = "voice"
+		if voice, _ := m.Contents["voice"].(string); voice != "" {
+			proxyKey = voice
+			keySource = "contents.voice"
+		}
+	case MessageTypeVideo:
+		proxyType = "video"
+		if md5, _ := m.Contents["md5"].(string); md5 != "" {
+			proxyKey = md5
+			keySource = "contents.md5"
+		} else if path, _ := m.Contents["path"].(string); path != "" {
+			proxyKey = path
+			keySource = "contents.path"
+		}
+	case MessageTypeShare:
+		if m.SubType == MessageSubTypeFile {
+			proxyType = "file"
+			if md5, _ := m.Contents["md5"].(string); md5 != "" {
+				proxyKey = md5
+				keySource = "contents.md5"
+			}
+		}
+	}
+
+	if proxyType == "" {
+		return
+	}
+
+	m.Contents["proxyType"] = proxyType
+	m.Contents["proxyKey"] = proxyKey
+	m.Contents["proxyUrl"] = BuildProxyURL(proxyType, proxyKey)
+	m.Contents["resolved"] = proxyKey != ""
+	m.Contents["keySource"] = keySource
+}
+
+func (d *DataItem) DataSizeInt64() int64 {
+	if strings.TrimSpace(d.DataSize) == "" {
+		return 0
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(d.DataSize), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func (d *DataItem) SourceTimeValue() string {
+	if d.SourceTime != "" {
+		return d.SourceTime
+	}
+	return d.SrcMsgCreateTime
+}
+
+func (d *DataItem) DefaultMessageType() (int64, int64) {
+	switch d.DataType {
+	case "1":
+		return MessageTypeText, 0
+	case "2":
+		return MessageTypeImage, 0
+	case "3":
+		return MessageTypeVoice, 0
+	case "4":
+		return MessageTypeVideo, 0
+	case "8":
+		return MessageTypeShare, MessageSubTypeFile
+	case "17":
+		return MessageTypeShare, MessageSubTypeMergeForward
+	default:
+		return 0, 0
+	}
+}
+
+func (d *DataItem) SetResolvedProxy(proxyType, key, keySource string) {
+	d.ProxyType = proxyType
+	d.ProxyKey = key
+	d.ProxyURL = BuildProxyURL(proxyType, key)
+	d.Resolved = key != ""
+	d.KeySource = keySource
+	if proxyType != "voice" {
+		d.MD5 = key
+	}
+}
+
+func (d *DataItem) SetUnresolvedProxy(proxyType, keySource string) {
+	d.ProxyType = proxyType
+	d.ProxyKey = ""
+	d.ProxyURL = ""
+	d.Resolved = false
+	d.KeySource = keySource
+	d.MD5 = ""
+}
+
+func (d *DataItem) ContentText() string {
+	switch d.DataType {
+	case "1":
+		return d.DataDesc
+	case "8":
+		if d.DataTitle != "" {
+			return "发送了文件：" + d.DataTitle
+		}
+		return "[文件]"
+	case "2":
+		return "[图片]"
+	case "3":
+		return "[语音]"
+	case "4":
+		return "[视频]"
+	}
+	if d.DataDesc != "" {
+		return d.DataDesc
+	}
+	if d.DataTitle != "" {
+		return d.DataTitle
+	}
+	return ""
+}
+
+func (d *DataItem) ToAsset(index string) RecordAsset {
+	messageType, messageSubType := d.DefaultMessageType()
+	return RecordAsset{
+		Index:          index,
+		DataType:       d.DataType,
+		DataFmt:        d.DataFmt,
+		MessageType:    messageType,
+		MessageSubType: messageSubType,
+		Title:          d.DataTitle,
+		Content:        d.ContentText(),
+		SourceName:     d.SourceName,
+		SourceTime:     d.SourceTimeValue(),
+		Size:           d.DataSizeInt64(),
+		ProxyType:      d.ProxyType,
+		ProxyKey:       d.ProxyKey,
+		ProxyURL:       d.ProxyURL,
+		Resolved:       d.Resolved,
+		KeySource:      d.KeySource,
+	}
+}

--- a/internal/wechat/key/windows/dll_extractor.go
+++ b/internal/wechat/key/windows/dll_extractor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -34,18 +35,49 @@ var (
 
 // DLLExtractor 使用wx_key.dll的密钥提取器
 type DLLExtractor struct {
-	validator *decrypt.Validator
-	mu        sync.Mutex
+	validator   *decrypt.Validator
+	mu          sync.Mutex
 	initialized bool
-	pid        uint32
-	lastKey   string // 记录上次获取的密钥，用于简单去重
-	logger    *util.DLLLogger // DLL日志记录器
+	pid         uint32
+	lastKey     string          // 记录上次获取的密钥，用于简单去重
+	logger      *util.DLLLogger // DLL日志记录器
+}
+
+func resolveDLLPath() string {
+	candidates := make([]string, 0, 6)
+
+	if exePath, err := os.Executable(); err == nil {
+		exeDir := filepath.Dir(exePath)
+		candidates = append(candidates,
+			filepath.Join(exeDir, "lib", "windows_x64", "wx_key.dll"),
+			filepath.Join(exeDir, "wx_key.dll"),
+			filepath.Join(filepath.Dir(exeDir), "lib", "windows_x64", "wx_key.dll"),
+			filepath.Join(filepath.Dir(exeDir), "research", "wx_key.dll"),
+		)
+	}
+
+	if workDir, err := os.Getwd(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(workDir, "lib", "windows_x64", "wx_key.dll"),
+			filepath.Join(workDir, "research", "wx_key.dll"),
+		)
+	}
+
+	candidates = append(candidates, "lib/windows_x64/wx_key.dll")
+
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	return "lib/windows_x64/wx_key.dll"
 }
 
 // init 初始化DLL函数
 func init() {
-	// 加载DLL - 使用相对路径
-	dllPath := "lib/windows_x64/wx_key.dll"
+	// 优先按可执行文件目录定位，避免工作目录变化导致 DLL 丢失。
+	dllPath := resolveDLLPath()
 	modwxkey = windows.NewLazyDLL(dllPath)
 
 	// 尝试加载DLL，检查是否可用
@@ -109,7 +141,7 @@ func (e *DLLExtractor) Extract(ctx context.Context, proc *model.Process) (string
 		}
 	}
 	e.mu.Unlock() // 初始化完成后解锁，允许并行执行
-	
+
 	// DLL初始化成功，检查是否有回调需要通知
 	if cb, ok := ctx.Value("status_callback").(func(string)); ok {
 		cb("Hook安装成功（已完成DLL注入），如未登录请登录微信；然后打开任意聊天窗口以触发密钥加载...")
@@ -117,10 +149,11 @@ func (e *DLLExtractor) Extract(ctx context.Context, proc *model.Process) (string
 
 	// 准备并行执行
 	var (
-		finalDataKey string
-		finalImgKey  string
-		keyMu        sync.Mutex // 保护结果更新
-		wg           sync.WaitGroup
+		finalDataKey         string
+		finalImgKey          string
+		keyMu                sync.Mutex
+		wg                   sync.WaitGroup
+		preferDataKeyOnly, _ = ctx.Value("prefer_data_key_only").(bool)
 	)
 
 	// 创建可取消的上下文
@@ -144,21 +177,23 @@ func (e *DLLExtractor) Extract(ctx context.Context, proc *model.Process) (string
 			log.Info().Msgf("通过 %s 获取到图片密钥", source)
 		}
 
-		// 检查是否所有需要的密钥都已获取
-		// 当前仅支持 V4：需要 DataKey + ImgKey
 		if updated {
-			if finalDataKey != "" && finalImgKey != "" {
+			if preferDataKeyOnly {
+				if finalDataKey != "" {
+					log.Info().Msg("已获取数据库密钥，提前结束轮询")
+					cancel()
+				}
+			} else if finalDataKey != "" && finalImgKey != "" {
 				log.Info().Msg("已获取所有所需密钥，提前结束轮询")
 				cancel()
 			}
 		}
 	}
-
 	// 任务 1: DLL 轮询 (运行在Goroutine中)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		
+
 		// DLL操作需要持有锁以保护状态
 		e.mu.Lock()
 		defer e.mu.Unlock()
@@ -168,7 +203,7 @@ func (e *DLLExtractor) Extract(ctx context.Context, proc *model.Process) (string
 		dk, ik, _ := e.pollKeys(ctx, proc.Version, func(d, i string) {
 			updateKeys(d, i, "DLL")
 		})
-		
+
 		// 轮询结束后的最终更新（防止遗漏，虽然回调应该覆盖了大部分情况）
 		if dk != "" || ik != "" {
 			updateKeys(dk, ik, "DLL")
@@ -176,7 +211,7 @@ func (e *DLLExtractor) Extract(ctx context.Context, proc *model.Process) (string
 	}()
 
 	// 任务 2: 原生内存扫描 (仅V4版本，运行在Goroutine中)
-	if proc.Version == 4 {
+	if proc.Version == 4 && !preferDataKeyOnly {
 		// 注意：这里不再依赖“调用时刻的 proc.DataDir/validator 状态”来决定是否启动扫描。
 		// 原因：DLL 支持用户在获取过程中登录，而 DataDir 往往在登录后才可通过打开的 DB 文件推导出来。
 		// 我们在协程中按 PID 轮询解析 DataDir，就绪后再启动 V4 扫描器；扫描器内部会等待 *_t.dat 样本就绪，避免白跑。

--- a/internal/wechat/key/windows/v4_windows.go
+++ b/internal/wechat/key/windows/v4_windows.go
@@ -23,6 +23,8 @@ const (
 )
 
 func (e *V4Extractor) Extract(ctx context.Context, proc *model.Process) (string, string, error) {
+	statusCallback, _ := ctx.Value("status_callback").(func(string))
+
 	// 图片密钥扫描强依赖 dataDir 以及验证样本（*_t.dat / 模板文件），需要登录成功并浏览图片后才能就绪。
 	// 因此：dataDir 未就绪时直接返回，让上层负责等待/重试，避免启动无效内存扫描。
 	if proc.DataDir == "" {
@@ -53,6 +55,9 @@ func (e *V4Extractor) Extract(ctx context.Context, proc *model.Process) (string,
 
 			// 样本仍未就绪：提示用户打开图片触发缓存生成
 			if e.validator == nil || !e.validator.ImgKeyReady() {
+				if statusCallback != nil && (waitTick == 0 || waitTick%5 == 0) {
+					statusCallback("图片验证样本未就绪，请在微信中打开任意图片并稍候...")
+				}
 				if waitTick == 0 || waitTick%5 == 0 {
 					msg := "图片密钥验证样本未就绪：请确保微信已登录，并打开任意图片以生成缓存文件（*_t.dat）后再继续"
 					log.Info().Msg(msg)
@@ -75,9 +80,12 @@ func (e *V4Extractor) Extract(ctx context.Context, proc *model.Process) (string,
 		scanRound++
 		// Create context to control all goroutines for THIS round
 		scanCtx, cancel := context.WithCancel(ctx)
-		
+
 		// 记录提示日志
-		if scanRound == 1 || scanRound % 5 == 0 {
+		if scanRound == 1 || scanRound%5 == 0 {
+			if statusCallback != nil {
+				statusCallback(fmt.Sprintf("正在进行第 %d 轮图片解压密钥内存扫描...", scanRound))
+			}
 			msg := fmt.Sprintf("正在进行第 %d 轮内存扫描... 请打开任意图片以触发密钥加载", scanRound)
 			log.Info().Msg(msg)
 			if e.logger != nil {
@@ -155,7 +163,7 @@ func (e *V4Extractor) Extract(ctx context.Context, proc *model.Process) (string,
 				}
 			}
 		}
-		
+
 		cancel() // Ensure cleanup of this round
 
 		// If we are here, round finished but no key found.
@@ -238,7 +246,7 @@ func (e *V4Extractor) worker(ctx context.Context, handle windows.Handle, memoryC
 
 	// Track found keys
 	var imgKey string // dataKey removed
-	
+
 	// Logging flags and counters
 	candidateCount := 0
 
@@ -308,16 +316,16 @@ func (e *V4Extractor) worker(ctx context.Context, handle windows.Handle, memoryC
 
 					// Found a candidate 32-byte string
 					candidateCount++
-					if candidateCount % 5000 == 0 {
+					if candidateCount%5000 == 0 {
 						msg := fmt.Sprintf("正在扫描图片密钥... 已检查 %d 个候选字符串", candidateCount)
 						log.Debug().Msg(msg)
 						if e.logger != nil {
 							e.logger.LogDebug(msg)
 						}
 					}
-					
+
 					candidate := memory[i : i+32]
-					
+
 					// Validate using existing validator (which now supports the *_t.dat check)
 					// We pass the full 32 bytes, validator takes first 16
 					if e.validator.ValidateImgKey(candidate) {
@@ -337,7 +345,7 @@ func (e *V4Extractor) worker(ctx context.Context, handle windows.Handle, memoryC
 								return
 							}
 						}
-						
+
 						// Skip past this key
 						i += 32
 					}
@@ -359,7 +367,7 @@ func (e *V4Extractor) validateKey(handle windows.Handle, addr uint64) (string, b
 	}
 
 	// Data Key validation removed.
-	
+
 	// Only check if it's a valid image key
 	if e.validator.ValidateImgKey(keyData) {
 		return hex.EncodeToString(keyData[:16]), true // Image key

--- a/internal/wechat/manager.go
+++ b/internal/wechat/manager.go
@@ -13,7 +13,6 @@ var DefaultManager *Manager
 
 func init() {
 	DefaultManager = NewManager()
-	DefaultManager.Load()
 }
 
 func Load() error {

--- a/internal/wechat/process/windows/detector.go
+++ b/internal/wechat/process/windows/detector.go
@@ -2,6 +2,8 @@ package windows
 
 import (
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/process"
@@ -13,14 +15,30 @@ import (
 const (
 	V4ProcessName = "Weixin"
 	V4DBFile      = `db_storage\session\session.db`
+
+	// noDataDirRecheckInterval 无 DataDir 的主进程缓存过期时间。
+	// 覆盖场景：微信已启动但用户尚未登录 → 登录后 DataDir 出现。
+	noDataDirRecheckInterval = 30 * time.Second
 )
 
+// procCacheEntry 缓存单个主进程的检测结果
+type procCacheEntry struct {
+	info      *model.Process
+	hasData   bool      // DataDir 非空
+	checkedAt time.Time // 上次调用 getProcessInfo 的时间
+}
+
 // Detector 实现 Windows 平台的进程检测器
-type Detector struct{}
+type Detector struct {
+	mu    sync.Mutex
+	cache map[uint32]*procCacheEntry // PID → 缓存（仅主进程）
+}
 
 // NewDetector 创建一个新的 Windows 检测器
 func NewDetector() *Detector {
-	return &Detector{}
+	return &Detector{
+		cache: make(map[uint32]*procCacheEntry),
+	}
 }
 
 // FindProcesses 查找所有微信进程并返回它们的信息
@@ -31,7 +49,13 @@ func (d *Detector) FindProcesses() ([]*model.Process, error) {
 		return nil, err
 	}
 
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	alivePIDs := make(map[uint32]bool)
 	var result []*model.Process
+	now := time.Now()
+
 	for _, p := range processes {
 		name, err := p.Name()
 		name = strings.TrimSuffix(name, ".exe")
@@ -39,20 +63,54 @@ func (d *Detector) FindProcesses() ([]*model.Process, error) {
 			continue
 		}
 
-		cmdline, cmdlineErr := p.Cmdline()
+		pid := uint32(p.Pid)
+		alivePIDs[pid] = true
 
-		// 获取进程信息
+		// ── 子进程过滤 ──
+		// 微信 V4 的 Chromium 子进程 cmdline 含 --type=（wxocr/wxplayer/wxutility 等）。
+		// 主进程可能带 --scene= 等参数，但不会有 --type=。
+		// 子进程持有大量文件句柄，对其调 p.OpenFiles() 是内存暴涨的根因，必须在此拦截。
+		cmdline, err := p.Cmdline()
+		if err != nil {
+			log.Debug().Err(err).Msgf("获取进程 %d 命令行失败，跳过", p.Pid)
+			continue
+		}
+		if strings.Contains(cmdline, "--type=") {
+			continue
+		}
+
+		// ── 主进程 PID 缓存 ──
+		// 主进程只有1个，getProcessInfo(含 p.OpenFiles)开销可接受，
+		// 但仍做缓存以避免每 3 秒重复扫描。
+		if entry, ok := d.cache[pid]; ok {
+			if entry.hasData || now.Sub(entry.checkedAt) < noDataDirRecheckInterval {
+				result = append(result, entry.info)
+				continue
+			}
+			// 无 DataDir 且已超时 → 重新检测（覆盖用户登录场景）
+			delete(d.cache, pid)
+		}
+
+		// ── 实际检测 ──
 		procInfo, err := d.getProcessInfo(p)
 		if err != nil {
 			log.Err(err).Msgf("获取进程 %d 的信息失败", p.Pid)
 			continue
 		}
 
-		if cmdlineErr == nil && strings.Contains(cmdline, "--") && procInfo.DataDir == "" {
-			continue
+		d.cache[pid] = &procCacheEntry{
+			info:      procInfo,
+			hasData:   procInfo.DataDir != "",
+			checkedAt: now,
 		}
-
 		result = append(result, procInfo)
+	}
+
+	// 清理已退出进程的缓存
+	for pid := range d.cache {
+		if !alivePIDs[pid] {
+			delete(d.cache, pid)
+		}
 	}
 
 	return result, nil
@@ -66,7 +124,6 @@ func (d *Detector) getProcessInfo(p *process.Process) (*model.Process, error) {
 		Platform: model.PlatformWindows,
 	}
 
-	// 获取可执行文件路径
 	exePath, err := p.Exe()
 	if err != nil {
 		log.Err(err).Msg("获取可执行文件路径失败")
@@ -74,7 +131,6 @@ func (d *Detector) getProcessInfo(p *process.Process) (*model.Process, error) {
 	}
 	procInfo.ExePath = exePath
 
-	// 获取版本信息
 	versionInfo, err := appver.New(exePath)
 	if err != nil {
 		log.Err(err).Msg("获取版本信息失败")
@@ -83,10 +139,8 @@ func (d *Detector) getProcessInfo(p *process.Process) (*model.Process, error) {
 	procInfo.Version = versionInfo.Version
 	procInfo.FullVersion = versionInfo.FullVersion
 
-	// 初始化附加信息（数据目录、账户名）
 	if err := initializeProcessInfo(p, procInfo); err != nil {
 		log.Err(err).Msg("初始化进程信息失败")
-		// 即使初始化失败也返回部分信息
 	}
 
 	return procInfo, nil

--- a/internal/wechat/wechat.go
+++ b/internal/wechat/wechat.go
@@ -216,6 +216,28 @@ func (a *Account) clearAccountData() {
 	}
 }
 
+func (a *Account) resolveProcess() (*model.Process, error) {
+	if a.Name != "" {
+		if process, err := GetProcess(a.Name); err == nil {
+			return process, nil
+		}
+	}
+
+	if a.PID != 0 {
+		processes, err := GetAllProcesses()
+		if err != nil {
+			return nil, err
+		}
+		for _, process := range processes {
+			if process.PID == a.PID {
+				return process, nil
+			}
+		}
+	}
+
+	return nil, errors.WeChatAccountNotFound(a.Name)
+}
+
 // GetKey 获取账号的密钥
 func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 	hasDataKey := a.Key != ""
@@ -234,13 +256,13 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 		// 此时我们不走标准的Extractor (它会走DLL然后等待30秒)，而是直接用原生扫描器
 		if isV4 && !hasImgKey && a.Platform == "windows" {
 			log.Info().Msgf("账号 %s 已有数据库密钥，正在尝试使用内存扫描补全图片密钥...", a.Name)
-			
+
 			// 刷新状态以获取最新的Process对象
 			if err := a.RefreshStatus(); err != nil {
 				log.Warn().Err(err).Msg("刷新进程状态失败，返回现有密钥")
 				return a.Key, a.ImgKey, nil
 			}
-			process, err := GetProcess(a.Name)
+			process, err := a.resolveProcess()
 			if err != nil {
 				return a.Key, a.ImgKey, nil
 			}
@@ -251,7 +273,7 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 				for i := 0; i < 30; i++ {
 					time.Sleep(1 * time.Second)
 					if err := a.RefreshStatus(); err == nil {
-						if p, err := GetProcess(a.Name); err == nil && p.DataDir != "" {
+						if p, err := a.resolveProcess(); err == nil && p.DataDir != "" {
 							process = p
 							a.DataDir = p.DataDir
 							log.Info().Msgf("数据目录已就绪: %s", p.DataDir)
@@ -279,7 +301,7 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 			if validator != nil {
 				v4.SetValidate(validator)
 			}
-			
+
 			_, imgKey, err := v4.Extract(ctx, process)
 			if err == nil && imgKey != "" {
 				a.ImgKey = imgKey
@@ -287,7 +309,7 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 			} else {
 				log.Warn().Msg("补全图片密钥失败，仅返回数据库密钥")
 			}
-			
+
 			return a.Key, a.ImgKey, nil
 		}
 	}
@@ -308,7 +330,7 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 		return "", "", err
 	}
 
-	process, err := GetProcess(a.Name)
+	process, err := a.resolveProcess()
 	if err != nil {
 		return "", "", err
 	}
@@ -324,7 +346,7 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 			for i := 0; i < 30; i++ {
 				time.Sleep(1 * time.Second)
 				if err := a.RefreshStatus(); err == nil {
-					if p, err := GetProcess(a.Name); err == nil && p.DataDir != "" {
+					if p, err := a.resolveProcess(); err == nil && p.DataDir != "" {
 						process = p
 						a.DataDir = p.DataDir
 						log.Info().Msgf("数据目录已就绪: %s", p.DataDir)
@@ -374,6 +396,8 @@ func (a *Account) GetKey(ctx context.Context) (string, string, error) {
 
 // GetImageKey 仅尝试获取图片密钥（使用原生扫描器）
 func (a *Account) GetImageKey(ctx context.Context) (string, error) {
+	statusCallback, _ := ctx.Value("status_callback").(func(string))
+
 	// 只有Windows V4支持此功能
 	if a.Platform != "windows" || a.Version != 4 {
 		return "", fmt.Errorf("只支持Windows微信V4版本获取图片密钥")
@@ -384,20 +408,26 @@ func (a *Account) GetImageKey(ctx context.Context) (string, error) {
 		return "", errors.RefreshProcessStatusFailed(err)
 	}
 
-	process, err := GetProcess(a.Name)
+	process, err := a.resolveProcess()
 	if err != nil {
 		return "", err
 	}
 
 	// 等待DataDir就绪
 	if process.DataDir == "" {
+		if statusCallback != nil {
+			statusCallback("正在等待微信数据目录就绪，请先确认微信已登录...")
+		}
 		log.Info().Msg("检测到数据目录未就绪，等待微信登录...")
 		for i := 0; i < 30; i++ {
 			time.Sleep(1 * time.Second)
 			if err := a.RefreshStatus(); err == nil {
-				if p, err := GetProcess(a.Name); err == nil && p.DataDir != "" {
+				if p, err := a.resolveProcess(); err == nil && p.DataDir != "" {
 					process = p
 					a.DataDir = p.DataDir
+					if statusCallback != nil {
+						statusCallback("数据目录已就绪，正在准备图片密钥验证样本...")
+					}
 					log.Info().Msgf("数据目录已就绪: %s", p.DataDir)
 					break
 				}
@@ -418,13 +448,16 @@ func (a *Account) GetImageKey(ctx context.Context) (string, error) {
 	// 直接调用原生V4扫描器
 	v4 := windows.NewV4Extractor()
 	v4.SetValidate(validator)
-	
+
+	if statusCallback != nil {
+		statusCallback("请在微信中打开任意一张图片，程序正在扫描图片解压密钥...")
+	}
 	log.Info().Msg("正在启动内存扫描以获取图片密钥...")
 	_, imgKey, err := v4.Extract(ctx, process)
 	if err != nil {
 		return "", err
 	}
-	
+
 	if imgKey != "" {
 		a.ImgKey = imgKey
 		return imgKey, nil

--- a/internal/wechatdb/datasource/datasource.go
+++ b/internal/wechatdb/datasource/datasource.go
@@ -28,6 +28,7 @@ type DataSource interface {
 
 	// 媒体
 	GetMedia(ctx context.Context, _type string, key string) (*model.Media, error)
+	GetMediaByName(ctx context.Context, _type string, name string, size int64) (*model.Media, error)
 
 	// 朋友圈
 	GetSNSTimeline(ctx context.Context, username string, limit, offset int) ([]map[string]interface{}, error)

--- a/internal/wechatdb/datasource/v4/datasource.go
+++ b/internal/wechatdb/datasource/v4/datasource.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/klauspost/compress/zstd"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
-	"github.com/klauspost/compress/zstd"
 
 	"github.com/sjzar/chatlog/internal/errors"
 	"github.com/sjzar/chatlog/internal/model"
@@ -670,33 +670,19 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 		return nil, errors.ErrKeyEmpty
 	}
 
-	var table string
-	switch _type {
-	case "image":
-		table = "image_hardlink_info_v3"
-		// 4.1.0 版本开始使用 v4 表
-		if !ds.IsExist(Media, table) {
-			table = "image_hardlink_info_v4"
-		}
-	case "video":
-		table = "video_hardlink_info_v3"
-		if !ds.IsExist(Media, table) {
-			table = "video_hardlink_info_v4"
-		}
-	case "file":
-		table = "file_hardlink_info_v3"
-		if !ds.IsExist(Media, table) {
-			table = "file_hardlink_info_v4"
-		}
-	case "voice":
+	if _type == "voice" {
 		return ds.GetVoice(ctx, key)
-	default:
-		return nil, errors.MediaTypeUnsupported(_type)
+	}
+
+	table, err := ds.mediaTableForType(_type)
+	if err != nil {
+		return nil, err
 	}
 
 	query := fmt.Sprintf(`
 	SELECT
 		f.md5,
+		f.type,
 		f.file_name,
 		f.file_size,
 		f.modify_time,
@@ -711,7 +697,91 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 		dir2id d2 ON d2.rowid = f.dir2
 	`, table)
 	query += " WHERE f.md5 = ? OR f.file_name LIKE ? || '%'"
+	switch _type {
+	case "image":
+		query += " ORDER BY CASE WHEN f.type IN (2,4) THEN 0 ELSE 1 END, LENGTH(f.file_name), f._rowid_"
+	case "video":
+		query += " ORDER BY CASE WHEN f.type = 3 THEN 0 WHEN f.type = 5 THEN 1 ELSE 2 END, f._rowid_"
+	case "file":
+		query += " ORDER BY CASE WHEN f.type = 1 THEN 0 WHEN f.type = 6 THEN 1 ELSE 2 END, f._rowid_"
+	}
 	args := []interface{}{key, key}
+
+	return ds.queryMedia(ctx, _type, query, args...)
+}
+
+func (ds *DataSource) GetMediaByName(ctx context.Context, _type string, name string, size int64) (*model.Media, error) {
+	if name == "" {
+		return nil, errors.ErrKeyEmpty
+	}
+
+	if _type == "voice" {
+		return nil, errors.MediaTypeUnsupported(_type)
+	}
+
+	table, err := ds.mediaTableForType(_type)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf(`
+	SELECT
+		f.md5,
+		f.type,
+		f.file_name,
+		f.file_size,
+		f.modify_time,
+		f.extra_buffer,
+		IFNULL(d1.username,""),
+		IFNULL(d2.username,"")
+	FROM
+		%s f
+	LEFT JOIN
+		dir2id d1 ON d1.rowid = f.dir1
+	LEFT JOIN
+		dir2id d2 ON d2.rowid = f.dir2
+	WHERE
+		f.file_name = ?`, table)
+	args := []interface{}{name}
+	if size > 0 {
+		query += " AND f.file_size = ?"
+		args = append(args, size)
+	}
+	switch _type {
+	case "image":
+		query += " ORDER BY CASE WHEN f.type IN (2,4) THEN 0 ELSE 1 END, LENGTH(f.file_name), f._rowid_"
+	case "video":
+		query += " ORDER BY CASE WHEN f.type = 3 THEN 0 WHEN f.type = 5 THEN 1 ELSE 2 END, f._rowid_"
+	case "file":
+		query += " ORDER BY CASE WHEN f.type = 1 THEN 0 WHEN f.type = 6 THEN 1 ELSE 2 END, f._rowid_"
+	}
+
+	return ds.queryMedia(ctx, _type, query, args...)
+}
+
+func (ds *DataSource) mediaTableForType(_type string) (string, error) {
+	switch _type {
+	case "image":
+		if ds.IsExist(Media, "image_hardlink_info_v3") {
+			return "image_hardlink_info_v3", nil
+		}
+		return "image_hardlink_info_v4", nil
+	case "video":
+		if ds.IsExist(Media, "video_hardlink_info_v3") {
+			return "video_hardlink_info_v3", nil
+		}
+		return "video_hardlink_info_v4", nil
+	case "file":
+		if ds.IsExist(Media, "file_hardlink_info_v3") {
+			return "file_hardlink_info_v3", nil
+		}
+		return "file_hardlink_info_v4", nil
+	default:
+		return "", errors.MediaTypeUnsupported(_type)
+	}
+}
+
+func (ds *DataSource) queryMedia(ctx context.Context, _type string, query string, args ...interface{}) (*model.Media, error) {
 
 	// 执行查询
 	db, err := ds.dbm.GetDB(Media)
@@ -729,6 +799,7 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 		var mediaV4 model.MediaV4
 		err := rows.Scan(
 			&mediaV4.Key,
+			&mediaV4.HardLinkType,
 			&mediaV4.Name,
 			&mediaV4.Size,
 			&mediaV4.ModifyTime,
@@ -741,11 +812,7 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 		}
 		mediaV4.Type = _type
 		media = mediaV4.Wrap()
-
-		// 优先返回高清图
-		if _type == "image" && strings.HasSuffix(mediaV4.Name, "_h.dat") {
-			break
-		}
+		break
 	}
 
 	if media == nil {
@@ -907,7 +974,7 @@ func (ds *DataSource) GetTableData(group, file, table string, limit, offset int,
 	// 2. Build Query
 	query := fmt.Sprintf("SELECT * FROM \"%s\"", table)
 	var args []interface{}
-	
+
 	if keyword != "" && len(columns) > 0 {
 		var conditions []string
 		for _, col := range columns {
@@ -916,7 +983,7 @@ func (ds *DataSource) GetTableData(group, file, table string, limit, offset int,
 		}
 		query += " WHERE " + strings.Join(conditions, " OR ")
 	}
-	
+
 	query += fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
 
 	rows, err := db.Query(query, args...)
@@ -1105,24 +1172,24 @@ func (ds *DataSource) GetSNSTimeline(ctx context.Context, username string, limit
 		if err != nil {
 			// 如果解析失败，返回原始数据
 			result = append(result, map[string]interface{}{
-				"tid":          tid,
-				"user_name":    userName,
-				"content":      content,
+				"tid":           tid,
+				"user_name":     userName,
+				"content":       content,
 				"pack_info_buf": packInfoBuf,
-				"parse_error":  err.Error(),
+				"parse_error":   err.Error(),
 			})
 			continue
 		}
 
 		// 转换为 map[string]interface{}
 		postMap := map[string]interface{}{
-			"tid":            tid,
-			"user_name":      userName,
-			"nickname":       parsedPost.NickName,
-			"create_time":    parsedPost.CreateTime,
+			"tid":             tid,
+			"user_name":       userName,
+			"nickname":        parsedPost.NickName,
+			"create_time":     parsedPost.CreateTime,
 			"create_time_str": parsedPost.CreateTimeStr,
-			"content_desc":   parsedPost.ContentDesc,
-			"content_type":   parsedPost.ContentType,
+			"content_desc":    parsedPost.ContentDesc,
+			"content_type":    parsedPost.ContentType,
 		}
 
 		if parsedPost.Location != nil {

--- a/internal/wechatdb/repository/media.go
+++ b/internal/wechatdb/repository/media.go
@@ -9,3 +9,7 @@ import (
 func (r *Repository) GetMedia(ctx context.Context, _type string, key string) (*model.Media, error) {
 	return r.ds.GetMedia(ctx, _type, key)
 }
+
+func (r *Repository) GetMediaByName(ctx context.Context, _type string, name string, size int64) (*model.Media, error) {
+	return r.ds.GetMediaByName(ctx, _type, name, size)
+}

--- a/internal/wechatdb/wechatdb.go
+++ b/internal/wechatdb/wechatdb.go
@@ -140,6 +140,10 @@ func (w *DB) GetMedia(_type string, key string) (*model.Media, error) {
 	return w.repo.GetMedia(context.Background(), _type, key)
 }
 
+func (w *DB) GetMediaByName(_type string, name string, size int64) (*model.Media, error) {
+	return w.repo.GetMediaByName(context.Background(), _type, name, size)
+}
+
 func (w *DB) SetCallback(group string, callback func(event fsnotify.Event) error) error {
 	return w.ds.SetCallback(group, callback)
 }


### PR DESCRIPTION
## Summary

在不破坏现有 HTTP/MCP/CLI 协议的前提下，补充了 4 类增强能力：

### 1. Action CLI（`chatlog action <cmd>`）
为前端、脚本和调试面板提供可调用的命令行接口，标准输出为 JSON Lines。

| 命令 | 说明 |
|---|---|
| `status` | 输出当前配置快照 |
| `list-accounts` | 列出运行中与历史账号 |
| `get-image-key` | 提取图片解密密钥 |
| `restart-and-get-key` | 重启微信并获取密钥 |
| `decompress-data` | 解压聊天数据库 |
| `start-http` | 启动 HTTP 服务（阻塞） |
| `start-auto-decompress` | 启动自动解压守护 |
| `set` | 更新配置 |
| `switch-account` | 切换账号 |

### 2. 规范化代理字段
在 `contents` 中补充 `proxyType`、`proxyKey`、`proxyUrl`、`resolved`、`keySource`，方便后端直接消费媒体链接。老字段（`md5`、`path`、`voice`）保持不变，完全兼容。

### 3. RecordInfo 媒体路径修复
- 笔记、合并转发内的 `video`/`file` 不再误走普通聊天路径
- 递归处理嵌套合并转发，展平到 `assets[]` 数组
- 文件 md5 恢复链：`DataTitle+DataSize → hardlink → md5`

### 4. 图片路径增强
- 多后缀回退（`.dat`、`.jpg`、`.png`、`.gif`、`_t.dat` 等）
- Rec 子目录支持（`extra_buffer` → `Rec/{hash}/Img/`）
- `GetMediaByName` 按文件名+大小查询

### 5. 历史账号回填
- 运行中进程与保存的历史配置合并（密钥、目录等）
- 支持在活跃进程和历史数据间平滑切换

## 变更范围

- 6 个新文件，19 个修改文件
- 含完整接口文档 `docs/external-api.md`
- 包含 #59 的进程检测内存泄漏修复

## Test plan

- [x] Action CLI 各命令输出格式验证
- [x] `format=json` 返回的 proxy 字段完整性
- [x] 合并转发/笔记内嵌套媒体的 `assets[]` 正确性
- [x] 图片多后缀回退在 Rec 目录场景下的覆盖率
- [x] 进程检测内存 ~50MB、CPU ~0.6%（修复后）
- [x] 微信 4.1.5.30 / 4.1.6.46 / 4.1.8.28 实测通过