### PR TITLE
Bump MCP callCompatEndpoint timeout 30s -> 300s

### DIFF
--- a/internal/chatlog/http/mcp.go
+++ b/internal/chatlog/http/mcp.go
@@ -350,7 +350,12 @@ func (s *Service) callCompatEndpoint(path string, q url.Values) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	// History queries against large message DBs routinely take 30-90 seconds
+	// (the handler re-decrypts source DBs from disk, scans up to GBs of
+	// media_0.db, etc.). The previous 30s here caused every MCP wx_history
+	// call to fail under realistic workloads even though the underlying
+	// HTTP /api/v1/history would eventually return 200.
+	resp, err := (&http.Client{Timeout: 300 * time.Second}).Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem

The MCP wrapper at \`internal/chatlog/http/mcp.go:353\` makes an HTTP loopback call back to \`/api/v1/history\` through \`callCompatEndpoint()\`:

\`\`\`go
resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
\`\`\`

With a hardcoded 30s client timeout, every MCP \`wx_history\` call against a non-tiny chat times out, even though the underlying \`/api/v1/history\` handler would eventually return 200.

## Reproduction

On a Windows host with WeChat 4.1.8.107 and ~6.5GB work_dir:

\`\`\`
$ curl -m 30 'http://127.0.0.1:5030/api/v1/history?chat=GROUP&limit=2'
# hits 30s, never returns
\`\`\`

Log shows the underlying handler eventually returns 200 in 30-90s; the MCP layer abandons after 30s and the caller (e.g. Claude Code MCP client) sees \`context deadline exceeded\`.

## Root cause of slow /history

1. \`auto_decrypt_debounce: 0\` (default) means chatlog re-decrypts source DBs on every call
2. \`media_0.db\` is GB-scale; \`/history\` plan scans it
3. Goroutine/handle accumulation makes subsequent calls slower

These are separate problems worth fixing later, but the 30s hardcoded MCP timeout is the *immediate* reason every MCP call fails even when the handler would succeed.

## Fix

Bump the timeout to 300s. Caller (Claude Code, custom client, etc.) can still apply a shorter timeout if desired.

\`\`\`diff
- resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+ resp, err := (&http.Client{Timeout: 300 * time.Second}).Do(req)
\`\`\`

## Test

After patching and rebuilding:
- \`mcp__chatlog__wx_history\` call against a 188-member group returns 3 messages successfully (took ~35s; previously hit MCP timeout at 30s).
- No regression on other MCP tools or the HTTP API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)